### PR TITLE
Normalize decade identifier 'Actual' -> 'actual' and use friendly labels in selectors

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1378,7 +1378,7 @@ function showSongsListCategorySelection() {
     const container = document.getElementById('songs-list-category-buttons');
     container.innerHTML = '';
 
-    const decadesOrder = ['80s', '90s', '00s', '10s', 'Actual', 'Todas', 'verano'];// Solo las décadas que quieres mostrar aquí
+    const decadesOrder = ['80s', '90s', '00s', '10s', 'actual', 'Todas', 'verano']; // Solo las décadas que quieres mostrar aquí
 
     decadesOrder.forEach(decadeId => {
          if (decadeId === 'Todas' || decadeId === 'verano') {
@@ -1841,7 +1841,7 @@ function populateOnlineSelectors() {
     const decadeSelect = document.getElementById('online-decade-select');
     const categorySelect = document.getElementById('online-category-select');
 
-    const decades = ['80s', '90s', '00s', '10s', 'Actual'];
+    const decades = ['80s', '90s', '00s', '10s', 'actual'];
     const categories = [
         { value: 'espanol', text: 'Canciones en Español' },
         { value: 'ingles', text: 'Canciones en Inglés' },
@@ -1857,7 +1857,7 @@ function populateOnlineSelectors() {
     decades.forEach(dec => {
         const option = document.createElement('option');
         option.value = dec;
-        option.textContent = dec;
+        option.textContent = decadeNames[dec] || dec;
         decadeSelect.appendChild(option);
     });
 
@@ -1904,7 +1904,7 @@ function populateInviteSelectors() {
     const decadeSelect = document.getElementById('invite-decade-select');
     const categorySelect = document.getElementById('invite-category-select');
 
-    const decades = ['80s', '90s', '00s', '10s', 'Actual'];
+    const decades = ['80s', '90s', '00s', '10s', 'actual'];
     const categories = [
         { value: 'espanol', text: 'Canciones en Español' },
         { value: 'ingles', text: 'Canciones en Inglés' },
@@ -1919,7 +1919,7 @@ function populateInviteSelectors() {
     decades.forEach(dec => {
         const option = document.createElement('option');
         option.value = dec;
-        option.textContent = dec;
+        option.textContent = decadeNames[dec] || dec;
         decadeSelect.appendChild(option);
     });
 


### PR DESCRIPTION
### Motivation
- Fix inconsistent decade identifier use between data files and UI selectors where some code used `Actual` but the data uses `actual`, causing missing entries and broken selectors.
- Ensure decade dropdowns show the human-friendly label instead of the raw identifier so users see localized names.

### Description
- Updated `frontend/js/main.js` to use `actual` (lowercase) in decade arrays and in the decades ordering used by song lists and selectors.
- Replaced raw option text with `decadeNames[dec] || dec` so decade selects (`online-decade-select` and `invite-decade-select`) display user-facing names instead of the identifier.
- Adjusted the `decadesOrder` used by `showSongsListCategorySelection()` to include `actual` and kept special cases for `Todas` and `verano` so consolidated flows continue to work.

### Testing
- Launched a static server with `python -m http.server 8000` from `frontend` and verified the front-end served successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html`, called `showScreen('create-online-screen')`, and saved a screenshot to `artifacts/online-selectors.png`, which completed without errors.
- Committed the change; no automated unit tests exist for this change so only the manual/browser script verification was executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a822959e4832f8ba9549f89a115cb)