### PR TITLE
Fix navigation in online screens and add online-menu button; UI & PWA enhancements

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -5,14 +5,14 @@
     --secondary-color: #00eaff;
     --background-start: #1a0033;
     --background-end: #000000;
-    --card-background: rgba(255, 255, 255, 0.08);
-    --text-color: #e0e0e0;
+    --card-background: rgba(255, 255, 255, 0.12);
+    --text-color: #f0f0f0;
     --light-text-color: #ffffff;
     --correct-color: #00cc00;
     --incorrect-color: #e6006e;
     --warning-color: #e6e600;
-    --shadow-base: 0 0 8px rgba(0, 255, 255, 0.25);
-    --button-shadow-neon: 0 0 8px var(--secondary-color), 0 0 12px var(--secondary-color);
+    --shadow-base: 0 0 6px rgba(0, 255, 255, 0.2);
+    --button-shadow-neon: 0 0 6px rgba(0, 234, 255, 0.5), 0 0 10px rgba(123, 0, 255, 0.35);
     --border-radius: 15px;
 }
 
@@ -47,9 +47,10 @@ html, body {
     border-radius: var(--border-radius);
     box-shadow: var(--shadow-base);
     text-align: center;
-    animation: fadeIn .7s ease-in-out;
+    animation: fadeIn .45s ease-out;
     border: 1px solid var(--secondary-color);
     backdrop-filter: blur(3px);
+    position: relative;
 }
 
 .screen.active {
@@ -57,8 +58,8 @@ html, body {
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
+    from { opacity: 0; transform: translateY(14px) scale(0.98); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 h1, h2, h3 {
@@ -86,6 +87,7 @@ h1 {
 .btn, .category-btn, .player-btn {
     display: block;
     width: 100%;
+    min-height: 52px;
     padding: 15px;
     margin-bottom: 15px;
     border: none;
@@ -127,17 +129,196 @@ h1 {
     box-shadow: 0 0 12px rgba(255, 193, 7, 0.7);
 }
 
+.password-field {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.password-field .text-input {
+    margin-bottom: 0;
+    flex: 1;
+}
+
+.icon-btn {
+    width: 52px;
+    height: 52px;
+    padding: 0;
+    margin-bottom: 0;
+    border-radius: 12px;
+    font-size: 1.2rem;
+}
+
+.small-link {
+    font-size: 0.95rem;
+    padding: 10px 12px;
+}
+
+.bell-btn {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid var(--secondary-color);
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--light-text-color);
+    font-size: 1.1rem;
+    cursor: pointer;
+    box-shadow: var(--shadow-base);
+}
+
+.bell-btn:hover {
+    box-shadow: 0 0 10px var(--secondary-color);
+}
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    z-index: 1200;
+}
+
+.modal-overlay.hidden {
+    display: none;
+}
+
+.modal-content {
+    width: min(520px, 100%);
+    background: #1c0c2e;
+    border-radius: var(--border-radius);
+    border: 1px solid rgba(0, 234, 255, 0.6);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.45);
+    padding: 24px;
+    text-align: center;
+}
+
+.modal-body {
+    text-align: left;
+    display: grid;
+    gap: 12px;
+    margin-bottom: 20px;
+    max-height: 60vh;
+    overflow-y: auto;
+    padding-right: 6px;
+}
+
+.modal-section-title {
+    font-weight: 700;
+    color: var(--secondary-color);
+    margin-top: 4px;
+}
+
+.modal-body ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.modal-body li {
+    margin-bottom: 6px;
+}
+
+.notification-item {
+    padding: 10px 12px;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.notification-item small {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.locked {
+    opacity: 0.7;
+    position: relative;
+}
+
+.locked::after {
+    content: '🔒';
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    font-size: 0.95rem;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 26px;
+    height: 26px;
+    margin-left: 8px;
+    padding: 0 6px;
+    border-radius: 999px;
+    background: var(--incorrect-color);
+    color: var(--light-text-color);
+    font-size: 0.85rem;
+    font-weight: 700;
+    box-shadow: 0 0 6px rgba(230, 0, 110, 0.6);
+}
+
+.invite-toast {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    max-width: 320px;
+    background: rgba(0, 0, 0, 0.85);
+    color: var(--light-text-color);
+    border: 1px solid var(--secondary-color);
+    border-radius: 12px;
+    padding: 14px 16px;
+    z-index: 1000;
+    box-shadow: var(--shadow-base);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    animation: toastSlideIn 0.25s ease-out;
+}
+
+.invite-toast p {
+    font-size: 0.95rem;
+    text-align: left;
+}
+
+.invite-toast .btn {
+    margin-bottom: 0;
+    padding: 10px 12px;
+    font-size: 0.95rem;
+}
+
+.invite-toast.hide {
+    animation: toastFadeOut 0.2s ease-in forwards;
+}
+
+@keyframes toastSlideIn {
+    from { opacity: 0; transform: translateY(-10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toastFadeOut {
+    from { opacity: 1; transform: translateY(0); }
+    to { opacity: 0; transform: translateY(-10px); }
+}
+
 /* Ajustes para el recuadro del encabezado del juego */
 .game-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 20px;
-    padding: 15px 20px;
+    padding: 18px 22px;
     min-height: 80px;
     background: rgba(0, 0, 0, 0.25);
     border-radius: 10px;
     border: 1px solid var(--secondary-color);
+    box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.2);
 }
 
 .game-header div {
@@ -209,7 +390,8 @@ h1 {
     align-items: center;
     justify-content: center;
     font-size: 3rem;
-    padding-left: 0px;
+    line-height: 1;
+    padding-left: 4px;
     box-shadow: 0 0 10px var(--secondary-color);
     border: 1px solid var(--secondary-color);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adivina la Canción</title>
+    <meta name="theme-color" content="#3b1b52">
+    <link rel="manifest" href="manifest.json">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Nunito:wght@400;700&display=swap" rel="stylesheet">
@@ -19,15 +21,22 @@
     <div id="login-screen" class="screen">
         <h2>Iniciar Sesión</h2>
         <input type="email" id="login-email" class="text-input" placeholder="Correo electrónico">
-        <input type="password" id="login-password" class="text-input" placeholder="Contraseña">
+        <div class="password-field">
+            <input type="password" id="login-password" class="text-input" placeholder="Contraseña">
+            <button class="btn icon-btn" type="button" onclick="togglePasswordVisibility('login-password', this)">👁️</button>
+        </div>
         <button class="btn" onclick="loginUser()">Entrar</button>
+        <button class="btn tertiary small-link" type="button" onclick="showPasswordRecoveryInfo()">¿Olvidaste tu contraseña?</button>
         <p class="small-text">¿No tienes cuenta? <a href="#" onclick="showScreen('register-screen')">Regístrate aquí</a></p>
     </div>
 
     <div id="register-screen" class="screen">
         <h2>Registro</h2>
         <input type="email" id="register-email" class="text-input" placeholder="Correo electrónico">
-        <input type="password" id="register-password" class="text-input" placeholder="Contraseña">
+        <div class="password-field">
+            <input type="password" id="register-password" class="text-input" placeholder="Contraseña">
+            <button class="btn icon-btn" type="button" onclick="togglePasswordVisibility('register-password', this)">👁️</button>
+        </div>
         <button class="btn" onclick="registerUser()">Registrar</button>
         <p class="small-text">¿Ya tienes cuenta? <a href="#" onclick="showScreen('login-screen')">Inicia sesión</a></p>
     </div>
@@ -41,13 +50,15 @@
     </div>
 
     <div id="decade-selection-screen" class="screen">
+        <button class="bell-btn" type="button" onclick="toggleNotificationsPanel()" aria-label="Ver notificaciones">🔔</button>
         <h2>Selecciona una década</h2>
         <div id="decade-buttons" class="button-container"></div>
 
-        <button class="category-btn" onclick="startSummerSongsGame()">Canciones del Verano</button>
+        <button id="summer-songs-btn" class="category-btn" onclick="startSummerSongsGame()">Canciones del Verano</button>
         <button class="btn tertiary" onclick="showOnlineMenu()">Jugar Online</button>
         <button class="btn tertiary" onclick="showStats()">Estadísticas</button>
         <button class="btn tertiary" onclick="showAllSongs()">Canciones</button>
+        <button class="btn tertiary" onclick="showInstructions()">Instrucciones</button>
 
 
         <button class="btn tertiary" onclick="exitGame()">Salir del Juego</button>
@@ -64,7 +75,7 @@
     <div id="online-mode-screen" class="screen">
         <h2>Jugar Online</h2>
         <button class="btn" onclick="showScreen('create-online-screen')">Crear Partida</button>
-        <button class="btn" onclick="showScreen('pending-games-screen')">Ver Partidas Recibidas</button>
+        <button class="btn" onclick="showScreen('pending-games-screen')">Ver Partidas Recibidas <span id="online-invite-count" class="badge" hidden>0</span></button>
         <button class="btn" onclick="showScreen('join-online-screen')">Unirse a Partida</button>
         <button class="btn" onclick="showScreen('invite-online-screen')">Invitar por Nombre</button>
         <button class="btn secondary" onclick="showScreen('decade-selection-screen')">Volver</button>
@@ -122,7 +133,8 @@
     <div id="online-wait-screen" class="screen">
         <h2>Esperando al Otro Jugador...</h2>
         <p id="online-status-text">Una vez ambos hayan terminado, verás el resultado.</p>
-         <button class="btn secondary" onclick="endOnlineModeAndGoHome()">Volver al Menú Online</button> </div>
+        <button class="btn secondary" onclick="goToOnlineMenu()">Volver al Menú Online</button>
+        <button class="btn tertiary" onclick="endOnlineModeAndGoHome()">Menú Principal</button>
     </div>
 
     <div id="statistics-screen" class="screen">
@@ -214,7 +226,8 @@
         <div id="winner-display"></div>
         <div id="final-scores"></div>
         <button class="btn" id="play-again-btn">Volver a Jugar</button>
-        <button class="btn secondary" onclick="endOnlineModeAndGoHome()">Menú Principal</button>
+        <button class="btn secondary" onclick="goToOnlineMenu()">Volver al Menú Online</button>
+        <button class="btn tertiary" onclick="endOnlineModeAndGoHome()">Menú Principal</button>
         <button class="btn tertiary" onclick="logout()">Salir del Juego</button>
     </div>
 
@@ -237,6 +250,150 @@
     <audio id="audio-player"></audio>
     <audio id="sfx-acierto" src="audio/sfx/acierto.mp3"></audio>
     <audio id="sfx-error" src="audio/sfx/error.mp3"></audio>
+
+    <div id="premium-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="premium-modal-title">
+        <div class="modal-content">
+            <h3 id="premium-modal-title">Contenido premium</h3>
+            <p id="premium-modal-message">Contenido premium. Próximamente disponible mediante desbloqueo.</p>
+            <button class="btn secondary" type="button" onclick="closePremiumModal()">Cerrar</button>
+        </div>
+    </div>
+
+    <div id="instructions-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="instructions-modal-title">
+        <div class="modal-content">
+            <h3 id="instructions-modal-title">Instrucciones</h3>
+            <div class="modal-body">
+                <p class="modal-section-title">🎵 ¿CÓMO JUGAR A ADIVINA LA CANCIÓN?</p>
+
+                <p class="modal-section-title">1. Inicio y acceso</p>
+                <p>Para jugar necesitas iniciar sesión o registrarte. Tus datos se guardan en el dispositivo, por lo que no tendrás que registrarte cada vez que entres.</p>
+                <p>Desde el menú principal podrás:</p>
+                <ul>
+                    <li>Iniciar una nueva partida.</li>
+                    <li>Volver a jugar tras terminar una sesión.</li>
+                    <li>Acceder a modos online y estadísticas.</li>
+                </ul>
+
+                <p class="modal-section-title">2. Selección de categoría</p>
+                <p>Elige la categoría musical en la que quieres jugar.</p>
+                <p><strong>Categorías disponibles</strong></p>
+                <ul>
+                    <li>Canciones en Español ✅ (gratuita)</li>
+                    <li>Canciones en Inglés ✅ (gratuita)</li>
+                </ul>
+                <p>Estas categorías están disponibles por década (80, 90, 2000, 2010 y Actual).</p>
+                <p><strong>Contenido premium 🔒</strong></p>
+                <p>Las siguientes categorías requieren desbloqueo:</p>
+                <ul>
+                    <li>Bandas Sonoras de Películas</li>
+                    <li>Bandas Sonoras de Series</li>
+                    <li>Programas de TV</li>
+                    <li>Series Infantiles</li>
+                    <li>Anuncios</li>
+                    <li>Modos especiales como “Todas las Décadas” o “Canciones del Verano”</li>
+                </ul>
+                <p>El desbloqueo es permanente y amplía la experiencia de juego.</p>
+
+                <p class="modal-section-title">3. Selección de jugadores</p>
+                <p>Puedes jugar:</p>
+                <ul>
+                    <li>En solitario</li>
+                    <li>De 2 a 6 jugadores en modo local</li>
+                </ul>
+                <p>En partidas multijugador local:</p>
+                <ul>
+                    <li>Los turnos se realizan de forma secuencial.</li>
+                    <li>Cada jugador tiene su propia puntuación.</li>
+                    <li>Gana quien más puntos consiga al final.</li>
+                </ul>
+
+                <p class="modal-section-title">4. Desarrollo de la partida</p>
+                <p>Cada partida consta de 10 preguntas. En cada pregunta:</p>
+                <ul>
+                    <li>Se reproduce un fragmento de audio.</li>
+                    <li>El jugador dispone de hasta 3 intentos para adivinar la canción.</li>
+                </ul>
+                <p>En cada intento se escucha un fragmento más largo del audio:</p>
+                <ul>
+                    <li>Primer intento: 4 segundos</li>
+                    <li>Segundo intento: 6 segundos</li>
+                    <li>Tercer intento: 10 segundos</li>
+                </ul>
+                <p>Tras cada intento fallido, la puntuación posible se reduce.</p>
+
+                <p class="modal-section-title">5. Sistema de puntuación</p>
+                <p>La puntuación depende del intento en el que aciertes:</p>
+                <ul>
+                    <li>✅ Primer intento → 3 puntos</li>
+                    <li>✅ Segundo intento → 2 puntos</li>
+                    <li>✅ Tercer intento → 1 punto</li>
+                    <li>❌ Sin acierto → 0 puntos</li>
+                </ul>
+                <p>La puntuación se actualiza en tiempo real durante la partida.</p>
+
+                <p class="modal-section-title">6. Interfaz durante el juego</p>
+                <p>Durante la partida dispondrás de:</p>
+                <ul>
+                    <li>Botón para reproducir el audio.</li>
+                    <li>Opciones de respuesta claras y accesibles.</li>
+                    <li>Acceso al menú.</li>
+                </ul>
+                <p>Siempre verás en pantalla:</p>
+                <ul>
+                    <li>Número de pregunta.</li>
+                    <li>Intentos restantes.</li>
+                    <li>Puntuación actual.</li>
+                </ul>
+                <p>El diseño está optimizado para pantallas táctiles.</p>
+
+                <p class="modal-section-title">7. Duelos Online 🌐</p>
+                <p>También puedes jugar contra otros jugadores online.</p>
+                <p><strong>Opciones disponibles</strong></p>
+                <ul>
+                    <li>Crear partida online.</li>
+                    <li>Unirse a una partida.</li>
+                    <li>Invitar por código de invitación.</li>
+                    <li>Invitar por nombre de usuario.</li>
+                    <li>Ver partidas recibidas.</li>
+                </ul>
+                <p>En los duelos online:</p>
+                <ul>
+                    <li>Cada jugador juega cuando quiere, desde su dispositivo.</li>
+                    <li>Las partidas pueden ser secuenciales o no, según disponibilidad.</li>
+                    <li>No es necesario que todos los jugadores jueguen al mismo tiempo.</li>
+                    <li>El sistema registra automáticamente los resultados.</li>
+                    <li>Gana el jugador que obtenga mayor puntuación.</li>
+                </ul>
+
+                <p class="modal-section-title">8. Final de la partida</p>
+                <p>Al finalizar las 10 preguntas:</p>
+                <ul>
+                    <li>Se muestra un resumen completo de la partida.</li>
+                    <li>En multijugador, se indica claramente el ganador.</li>
+                </ul>
+                <p>Opciones disponibles:</p>
+                <ul>
+                    <li>Volver a jugar.</li>
+                    <li>Cambiar de categoría.</li>
+                    <li>Volver al menú principal.</li>
+                    <li>Salir del juego.</li>
+                </ul>
+
+                <p class="modal-section-title">⭐ Consejo</p>
+                <p>Empieza con las categorías gratuitas para familiarizarte con el juego y, si te gusta, desbloquea nuevas categorías para ampliar el reto y la diversión.</p>
+                <p>¡Demuestra cuánto sabes de música y reta a tus amigos! 🎶🎉</p>
+            </div>
+            <button class="btn secondary" type="button" onclick="closeInstructions()">Cerrar</button>
+        </div>
+    </div>
+
+    <div id="notifications-panel" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="notifications-title">
+        <div class="modal-content">
+            <h3 id="notifications-title">Notificaciones</h3>
+            <div id="notifications-list" class="modal-body"></div>
+            <button class="btn secondary" type="button" onclick="toggleNotificationsPanel()">Cerrar</button>
+        </div>
+    </div>
 
     <script src="js/songs-loader.js"></script>
     <script src="js/main.js"></script>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -21,6 +21,23 @@ const categoryNames = {
     consolidated: "Todas las Categorías" // Usado para la opción 'Todas'
 };
 
+function getDecadeLabel(decadeId) {
+    return decadeNames[decadeId] || decadeId;
+}
+
+function getCategoryLabel(categoryId) {
+    return categoryNames[categoryId] || categoryId;
+}
+
+const BASE_DECADES = Array.isArray(window.allDecadesDefined)
+    ? window.allDecadesDefined
+    : ['80s', '90s', '00s', '10s', 'actual', 'verano'];
+const DECADES_ORDER = BASE_DECADES.filter(decade => decade !== 'verano');
+const DECADES_WITH_SPECIALS = [...DECADES_ORDER, 'Todas', 'verano'];
+const CATEGORY_ORDER = Array.isArray(window.allPossibleCategories)
+    ? window.allPossibleCategories
+    : ['espanol', 'ingles', 'peliculas', 'series', 'tv', 'infantiles', 'anuncios'];
+
 let gameState = {};
 let audioPlaybackTimeout;
 const screens = document.querySelectorAll('.screen');
@@ -34,10 +51,141 @@ let currentUser = null;
 let userAccumulatedScores = {}; 
 let gameHistory = []; 
 
+const PREMIUM_CATEGORIES = new Set(['peliculas', 'series', 'tv', 'infantiles', 'anuncios']);
+const PREMIUM_DECADES = new Set(['Todas', 'verano']);
+const ADMIN_EMAIL = 'vtornet@gmail.com';
+const NOTIFICATIONS_STORAGE_KEY = 'localNotifications';
+const PERMISSIONS_STORAGE_KEY = 'userPermissions';
+
 function getCurrentUserData() {
     const userDataString = localStorage.getItem("userData");
     if (!userDataString) return null;
     return JSON.parse(userDataString);
+}
+
+function getUserPermissions(email) {
+    const storedPermissions = JSON.parse(localStorage.getItem(PERMISSIONS_STORAGE_KEY) || '{}');
+    if (!storedPermissions[email]) {
+        storedPermissions[email] = {
+            email,
+            unlocked_sections: [],
+            no_ads: false,
+            is_admin: false
+        };
+    }
+
+    if (email === ADMIN_EMAIL) {
+        storedPermissions[email] = {
+            email,
+            unlocked_sections: ['premium_all'],
+            no_ads: true,
+            is_admin: true
+        };
+    }
+
+    localStorage.setItem(PERMISSIONS_STORAGE_KEY, JSON.stringify(storedPermissions));
+    return storedPermissions[email];
+}
+
+function hasPremiumAccess() {
+    if (!currentUser || !currentUser.email) return false;
+    const permissions = getUserPermissions(currentUser.email);
+    return permissions.is_admin || permissions.unlocked_sections.includes('premium_all');
+}
+
+function isPremiumCategory(categoryId) {
+    return PREMIUM_CATEGORIES.has(categoryId);
+}
+
+function isPremiumDecade(decadeId) {
+    return PREMIUM_DECADES.has(decadeId);
+}
+
+function isPremiumSelection(decadeId, categoryId) {
+    if (isPremiumDecade(decadeId)) return true;
+    if (isPremiumCategory(categoryId)) return true;
+    return false;
+}
+
+function showPremiumModal(message) {
+    const modal = document.getElementById('premium-modal');
+    const text = document.getElementById('premium-modal-message');
+    if (!modal || !text) return;
+    text.textContent = message || 'Contenido premium. Próximamente disponible mediante desbloqueo.';
+    modal.classList.remove('hidden');
+}
+
+function closePremiumModal() {
+    const modal = document.getElementById('premium-modal');
+    if (modal) modal.classList.add('hidden');
+}
+
+function showInstructions() {
+    const modal = document.getElementById('instructions-modal');
+    if (modal) modal.classList.remove('hidden');
+}
+
+function closeInstructions() {
+    const modal = document.getElementById('instructions-modal');
+    if (modal) modal.classList.add('hidden');
+}
+
+function getNotifications() {
+    const stored = localStorage.getItem(NOTIFICATIONS_STORAGE_KEY);
+    if (stored) {
+        return JSON.parse(stored);
+    }
+
+    const initial = [
+        {
+            id: 'welcome-premium',
+            message: 'Próximamente podrás desbloquear nuevas categorías.',
+            date: new Date().toLocaleDateString()
+        }
+    ];
+    localStorage.setItem(NOTIFICATIONS_STORAGE_KEY, JSON.stringify(initial));
+    return initial;
+}
+
+function renderNotifications() {
+    const list = document.getElementById('notifications-list');
+    if (!list) return;
+    const notifications = getNotifications();
+    list.innerHTML = '';
+    if (notifications.length === 0) {
+        list.innerHTML = '<p>No hay notificaciones todavía.</p>';
+        return;
+    }
+
+    notifications.forEach(note => {
+        const item = document.createElement('div');
+        item.className = 'notification-item';
+        item.innerHTML = `<p>${note.message}</p><small>${note.date}</small>`;
+        list.appendChild(item);
+    });
+}
+
+function toggleNotificationsPanel() {
+    const panel = document.getElementById('notifications-panel');
+    if (!panel) return;
+    const isHidden = panel.classList.contains('hidden');
+    if (isHidden) {
+        renderNotifications();
+        panel.classList.remove('hidden');
+    } else {
+        panel.classList.add('hidden');
+    }
+}
+
+function updatePremiumButtonsState() {
+    const summerButton = document.getElementById('summer-songs-btn');
+    if (!summerButton) return;
+
+    if (hasPremiumAccess()) {
+        summerButton.classList.remove('locked');
+    } else {
+        summerButton.classList.add('locked');
+    }
 }
 
 // main.js - Función showScreen
@@ -54,10 +202,56 @@ function showScreen(screenId) {
     if (screenId === 'invite-online-screen') {
         populateInviteSelectors();
     }
+    if (screenId === 'decade-selection-screen') {
+        updatePremiumButtonsState();
+    }
     // MODIFICACIÓN CLAVE AQUÍ:
     if (screenId === 'pending-games-screen' || screenId === 'online-mode-screen') { //
         loadPlayerOnlineGames(); //
+        requestInviteNotificationPermission();
     }
+}
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('sw.js').catch(error => {
+            console.warn('No se pudo registrar el Service Worker:', error);
+        });
+    });
+}
+
+function populateDecadeOptions(selectElement, decades) {
+    selectElement.innerHTML = '';
+    decades.forEach(dec => {
+        const option = document.createElement('option');
+        option.value = dec;
+        option.textContent = getDecadeLabel(dec);
+        selectElement.appendChild(option);
+    });
+}
+
+function populateCategoryOptions(selectElement, categories) {
+    selectElement.innerHTML = '';
+    categories.forEach(cat => {
+        const option = document.createElement('option');
+        option.value = cat;
+        option.textContent = getCategoryLabel(cat);
+        selectElement.appendChild(option);
+    });
+}
+
+function togglePasswordVisibility(inputId, button) {
+    const input = document.getElementById(inputId);
+    if (!input) return;
+
+    const isPassword = input.type === 'password';
+    input.type = isPassword ? 'text' : 'password';
+    button.textContent = isPassword ? '🙈' : '👁️';
+    button.setAttribute('aria-pressed', String(isPassword));
+}
+
+function showPasswordRecoveryInfo() {
+    alert('La recuperación de contraseña estará disponible próximamente. Si necesitas ayuda, contacta con el administrador.');
 }
 
 // =====================================================================
@@ -129,6 +323,7 @@ async function loginUser() {
 
         if (response.ok) {
             currentUser = { email: data.user.email, playerName: data.user.playerName };
+            getUserPermissions(currentUser.email);
             localStorage.setItem('loggedInUserEmail', data.user.email);
             localStorage.setItem('userData', JSON.stringify(currentUser));
 
@@ -143,6 +338,7 @@ async function loginUser() {
                 showScreen('decade-selection-screen'); 
                 // AHORA: Llamamos a generateDecadeButtons solo cuando sabemos que vamos a esa pantalla
                 generateDecadeButtons(); 
+                updatePremiumButtonsState();
             } else {
                 showScreen('set-player-name-screen');
             }
@@ -215,6 +411,16 @@ function endOnlineModeAndGoHome() {
     // Y siempre redirigir a la pantalla de selección de década
     showScreen('decade-selection-screen'); 
     generateDecadeButtons(); // Asegurarse de que los botones de década se generen correctamente
+}
+
+function goToOnlineMenu() {
+    isOnlineMode = false;
+    currentOnlineGameCode = null;
+    currentOnlineSongs = [];
+    currentOnlineEmail = null;
+    currentOnlinePlayerName = null;
+    localStorage.removeItem('currentOnlineGameData');
+    showScreen('online-mode-screen');
 }
 
 const RECENT_SONGS_HISTORY_LENGTH = 8; // Número de partidas hacia atrás para evitar repeticiones
@@ -450,20 +656,21 @@ function parseDisplay(displayText) {
 async function generateDecadeButtons() {
     const container = document.getElementById('decade-buttons');
     container.innerHTML = '';
-    const decadesOrder = ['80s', '90s', '00s', '10s', 'actual']; // Aquí está 'Actual'
-
-    decadesOrder.forEach(decadeId => {
+    DECADES_ORDER.forEach(decadeId => {
         const button = document.createElement('button');
         button.className = 'category-btn';
-        button.innerText = decadeNames[decadeId];
+        button.innerText = getDecadeLabel(decadeId);
         button.onclick = () => selectDecade(decadeId);
         container.appendChild(button);
     });
 
     const allButton = document.createElement('button');
     allButton.className = 'category-btn tertiary';
-    allButton.innerText = decadeNames['Todas'];
+    allButton.innerText = getDecadeLabel('Todas');
     allButton.onclick = () => selectDecade('Todas');
+    if (!hasPremiumAccess()) {
+        allButton.classList.add('locked');
+    }
     container.appendChild(allButton);
 }
 
@@ -477,6 +684,10 @@ async function selectDecade(decade) {
         showScreen('login-screen');
         return;
     }
+    if (isPremiumDecade(decade) && !hasPremiumAccess()) {
+        showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
+        return;
+    }
     gameState.selectedDecade = decade;
     
     if (decade === 'Todas') {
@@ -486,7 +697,7 @@ async function selectDecade(decade) {
             // Verificar que hay suficientes canciones para empezar una partida en modo "Todas"
             // (10 preguntas por jugador, por lo tanto, mínimo 10 canciones si hay 1 jugador)
             if (configuracionCanciones['Todas']['consolidated'].length < gameState.totalQuestionsPerPlayer) {
-                alert(`No hay suficientes canciones para jugar en la opción '${decadeNames['Todas']}'. Necesitas al menos ${gameState.totalQuestionsPerPlayer} canciones en total.`);
+                alert(`No hay suficientes canciones para jugar en la opción '${getDecadeLabel('Todas')}'. Necesitas al menos ${gameState.totalQuestionsPerPlayer} canciones en total.`);
                 showScreen('decade-selection-screen'); // Vuelve si no hay suficientes
                 return;
             }
@@ -527,15 +738,16 @@ function generateCategoryButtons() {
         return;
     }
 
-    const categoryOrder = ['espanol', 'ingles', 'peliculas', 'series', 'tv', 'infantiles', 'anuncios'];
-
-    categoryOrder.forEach(categoryId => {
+    CATEGORY_ORDER.forEach(categoryId => {
         const songsArray = currentDecadeSongs[categoryId]; // Asegurarse de obtener el array de canciones
         if (Array.isArray(songsArray) && songsArray.length >= 4) { // Validar que sea un array y tenga suficientes canciones
             const button = document.createElement('button');
             button.className = 'category-btn';
-            button.innerText = categoryNames[categoryId];
+            button.innerText = getCategoryLabel(categoryId);
             button.onclick = () => selectCategory(categoryId);
+            if (isPremiumCategory(categoryId) && !hasPremiumAccess()) {
+                button.classList.add('locked');
+            }
             container.appendChild(button);
         }
     });
@@ -555,19 +767,23 @@ async function selectCategory(category) {
         showScreen('login-screen');
         return;
     }
+    if (isPremiumCategory(category) && !hasPremiumAccess()) {
+        showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
+        return;
+    }
     gameState.category = category;
 
     try {
         await loadSongsForDecadeAndCategory(gameState.selectedDecade, gameState.category);
         // Verificar si la categoría tiene suficientes canciones después de la carga
         if (configuracionCanciones[gameState.selectedDecade][gameState.category].length < 4) {
-            alert(`No hay suficientes canciones en la categoría '${categoryNames[category]}' para la década ${decadeNames[gameState.selectedDecade]}. Necesitas al menos 4 canciones.`);
+            alert(`No hay suficientes canciones en la categoría '${getCategoryLabel(category)}' para la década ${getDecadeLabel(gameState.selectedDecade)}. Necesitas al menos 4 canciones.`);
             showScreen('category-screen'); // Volver a la selección de categoría
             return;
         }
         showScreen('player-selection-screen');
     }  catch (error) {
-        alert(`No se pudieron cargar las canciones para la categoría ${categoryNames[category]} en la década ${decadeNames[gameState.selectedDecade]}. Intenta con otra.`);
+        alert(`No se pudieron cargar las canciones para la categoría ${getCategoryLabel(category)} en la década ${getDecadeLabel(gameState.selectedDecade)}. Intenta con otra.`);
         console.error(error);
         showScreen('category-screen');
     }
@@ -597,6 +813,11 @@ function selectPlayers(numPlayers) {
         input.placeholder = `Nombre del Jugador ${i + 1}`;
         input.id = `player-${i + 1}-name-input`;
         otherPlayerNamesInputsDiv.appendChild(input);
+    }
+
+    if (numPlayers === 1) {
+        startGame();
+        return;
     }
 
     showScreen('player-names-input-screen');
@@ -695,6 +916,10 @@ async function startElderlyModeGame() {
 // main.js - Nueva función para el modo "Canciones del Verano"
 // main.js - Función MODIFICADA para el modo "Canciones del Verano"
 async function startSummerSongsGame() {
+    if (!hasPremiumAccess()) {
+        showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
+        return;
+    }
     if (!currentUser || !currentUser.playerName) {
         alert('Debes iniciar sesión y establecer tu nombre de jugador para continuar.');
         showScreen('login-screen');
@@ -784,7 +1009,7 @@ function startGame() {
         allSongsToChooseFrom = [...configuracionCanciones['Todas']['consolidated']];
     } else {
         if (!configuracionCanciones[gameState.selectedDecade] || !configuracionCanciones[gameState.selectedDecade][gameState.category]) {
-            alert(`Error: No se encontraron canciones para la década ${decadeNames[gameState.selectedDecade]} y categoría ${categoryNames[gameState.category]}.`);
+            alert(`Error: No se encontraron canciones para la década ${getDecadeLabel(gameState.selectedDecade)} y categoría ${getCategoryLabel(gameState.category)}.`);
             showScreen('decade-selection-screen');
             return;
         }
@@ -794,10 +1019,10 @@ function startGame() {
     const requiredSongs = gameState.totalQuestionsPerPlayer * gameState.playerCount;
 
     if (allSongsToChooseFrom.length < requiredSongs) {
-        console.warn(`Advertencia: No hay suficientes canciones en ${decadeNames[gameState.selectedDecade]} - ${categoryNames[gameState.category]}. Se necesitan ${requiredSongs} y solo hay ${allSongsToChooseFrom.length}. Ajustando el número de preguntas por jugador.`);
+        console.warn(`Advertencia: No hay suficientes canciones en ${getDecadeLabel(gameState.selectedDecade)} - ${getCategoryLabel(gameState.category)}. Se necesitan ${requiredSongs} y solo hay ${allSongsToChooseFrom.length}. Ajustando el número de preguntas por jugador.`);
         gameState.totalQuestionsPerPlayer = Math.floor(allSongsToChooseFrom.length / gameState.playerCount);
         if (gameState.totalQuestionsPerPlayer < 1) { 
-             alert(`No hay suficientes canciones en ${decadeNames[gameState.selectedDecade]} - ${categoryNames[gameState.category]} para que cada jugador tenga al menos una pregunta. Elige otra década o categoría.`);
+             alert(`No hay suficientes canciones en ${getDecadeLabel(gameState.selectedDecade)} - ${getCategoryLabel(gameState.category)} para que cada jugador tenga al menos una pregunta. Elige otra década o categoría.`);
              showScreen('decade-selection-screen');
              return;
         }
@@ -875,7 +1100,7 @@ function setupQuestion() {
     const currentQuestion = currentPlayer.questions[currentPlayer.questionsAnswered];
     
     document.getElementById("player-name-display").textContent = currentPlayer.name;
-    document.getElementById('category-display').innerText = `${decadeNames[gameState.selectedDecade]} - ${categoryNames[gameState.category]}`;
+    document.getElementById('category-display').innerText = `${getDecadeLabel(gameState.selectedDecade)} - ${getCategoryLabel(gameState.category)}`;
     document.getElementById('question-counter').innerText = `Pregunta ${currentPlayer.questionsAnswered + 1}/${gameState.totalQuestionsPerPlayer}`;
     document.getElementById('player-turn').innerText = `Turno de ${currentPlayer.name}`;
     document.getElementById('points-display').innerText = `Puntos: ${currentPlayer.score}`;
@@ -1261,7 +1486,7 @@ function renderUserTotalScores() {
         return;
     }
 
-    const decadesInOrder = ['80s', '90s', '00s', '10s', 'actual', 'Todas', 'verano'];
+    const decadesInOrder = DECADES_WITH_SPECIALS;
     let hasScoresToDisplay = false;
 
     decadesInOrder.forEach(decadeId => {
@@ -1272,13 +1497,13 @@ function renderUserTotalScores() {
             decadeHeader.style.color = 'var(--secondary-color)';
             decadeHeader.style.marginTop = '15px';
             decadeHeader.style.marginBottom = '10px';
-            decadeHeader.textContent = decadeNames[decadeId];
+            decadeHeader.textContent = getDecadeLabel(decadeId);
             categoryScoresList.appendChild(decadeHeader);
 
             const sortedCategoriesInDecade = Object.entries(categoriesInDecade).sort(([, scoreA], [, scoreB]) => scoreB - scoreA);
 
             sortedCategoriesInDecade.forEach(([categoryId, score]) => {
-                const categoryNameDisplay = categoryNames[categoryId] || categoryId;
+                const categoryNameDisplay = getCategoryLabel(categoryId);
                 const p = document.createElement('p');
                 p.className = 'score-item';
                 p.innerHTML = `• ${categoryNameDisplay}: <strong>${score} puntos</strong>`;
@@ -1358,7 +1583,7 @@ function renderDuelHistory() {
             listItem.style.fontSize = '0.85rem';
             listItem.style.marginBottom = '3px';
             listItem.style.color = 'var(--text-color)';
-            listItem.textContent = `Fecha: ${game.date}, Ganador: ${game.winner}, Década: ${decadeNames[game.decade] || game.decade}, Categoría: ${categoryNames[game.category] || game.category}`;
+            listItem.textContent = `Fecha: ${game.date}, Ganador: ${game.winner}, Década: ${getDecadeLabel(game.decade)}, Categoría: ${getCategoryLabel(game.category)}`;
             detailsList.appendChild(listItem);
         });
 
@@ -1373,22 +1598,35 @@ function renderDuelHistory() {
 /**
  * Muestra la pantalla para seleccionar una categoría y década para ver el listado de canciones.
  */
-function showSongsListCategorySelection() {
+async function showSongsListCategorySelection() {
     showScreen('songs-list-category-screen');
     const container = document.getElementById('songs-list-category-buttons');
     container.innerHTML = '';
 
-    const decadesOrder = ['80s', '90s', '00s', '10s', 'Actual', 'Todas', 'verano'];// Solo las décadas que quieres mostrar aquí
+    const decadesToLoad = DECADES_WITH_SPECIALS.filter(decadeId => decadeId !== 'Todas' && decadeId !== 'verano');
+    const loadPromises = decadesToLoad.flatMap(decadeId => (
+        CATEGORY_ORDER.map(categoryId => (
+            loadSongsForDecadeAndCategory(decadeId, categoryId).catch(error => {
+                console.warn(`No se pudo cargar la categoría ${categoryId} para la década ${decadeId}.`, error);
+                return null;
+            })
+        ))
+    ));
 
-    decadesOrder.forEach(decadeId => {
-         if (decadeId === 'Todas' || decadeId === 'verano') {
+    await Promise.allSettled(loadPromises);
+
+    DECADES_WITH_SPECIALS.forEach(decadeId => {
+        if (decadeId === 'Todas' || decadeId === 'verano') {
             const allButtonDiv = document.createElement('div');
             allButtonDiv.style.gridColumn = '1 / -1'; 
             allButtonDiv.style.marginTop = '20px';
             const allButton = document.createElement('button');
             allButton.className = 'category-btn tertiary';
-            allButton.innerText = decadeNames[decadeId];
+            allButton.innerText = getDecadeLabel(decadeId);
             allButton.onclick = () => displaySongsForCategory(decadeId, 'consolidated');
+            if (!hasPremiumAccess()) {
+                allButton.classList.add('locked');
+            }
             allButtonDiv.appendChild(allButton);
             container.appendChild(allButtonDiv);
             return; 
@@ -1397,7 +1635,7 @@ function showSongsListCategorySelection() {
         const decadeCategorySongs = configuracionCanciones[decadeId];
         if (decadeCategorySongs) {
             const decadeHeader = document.createElement('h3');
-            decadeHeader.textContent = decadeNames[decadeId];
+            decadeHeader.textContent = getDecadeLabel(decadeId);
             decadeHeader.style.color = 'var(--secondary-color)';
             decadeHeader.style.marginTop = '20px';
             decadeHeader.style.marginBottom = '10px';
@@ -1409,15 +1647,16 @@ function showSongsListCategorySelection() {
             categoryButtonsForDecadeDiv.style.gap = '10px';
             container.appendChild(categoryButtonsForDecadeDiv);
 
-            const categoryOrder = ['espanol', 'ingles', 'peliculas', 'series', 'tv', 'infantiles', 'anuncios'];
-
-            categoryOrder.forEach(categoryId => {
+            CATEGORY_ORDER.forEach(categoryId => {
                 const songsArray = decadeCategorySongs[categoryId];
                 if (Array.isArray(songsArray) && songsArray.length > 0) { 
                     const button = document.createElement('button');
                     button.className = 'category-btn';
-                    button.innerText = categoryNames[categoryId];
+                    button.innerText = getCategoryLabel(categoryId);
                     button.onclick = () => displaySongsForCategory(decadeId, categoryId);
+                    if (isPremiumCategory(categoryId) && !hasPremiumAccess()) {
+                        button.classList.add('locked');
+                    }
                     categoryButtonsForDecadeDiv.appendChild(button);
                 }
             });
@@ -1434,6 +1673,10 @@ async function displaySongsForCategory(decadeId, categoryId) {
     let songsToDisplay;
 
     try {
+        if (isPremiumSelection(decadeId, categoryId) && !hasPremiumAccess()) {
+            showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
+            return;
+        }
         if (decadeId === 'Todas') {
             await loadSongsForDecadeAndCategory('Todas', 'consolidated'); 
             songsToDisplay = configuracionCanciones['Todas']['consolidated'];
@@ -1442,7 +1685,7 @@ async function displaySongsForCategory(decadeId, categoryId) {
             songsToDisplay = configuracionCanciones[decadeId][categoryId];
         }
     } catch (error) {
-        alert(`No se pudo cargar la lista de canciones para ${decadeNames[decadeId]} - ${categoryNames[categoryId]}.`);
+        alert(`No se pudo cargar la lista de canciones para ${getDecadeLabel(decadeId)} - ${getCategoryLabel(categoryId)}.`);
         console.error(error);
         showScreen('songs-list-category-screen');
         return;
@@ -1452,7 +1695,7 @@ async function displaySongsForCategory(decadeId, categoryId) {
     const songsListCategoryTitle = document.getElementById('songs-list-category-title');
 
     songsListContainer.innerHTML = '';
-    songsListCategoryTitle.textContent = `Canciones de ${decadeNames[decadeId]} - ${categoryNames[categoryId]}`;
+    songsListCategoryTitle.textContent = `Canciones de ${getDecadeLabel(decadeId)} - ${getCategoryLabel(categoryId)}`;
 
     if (!songsToDisplay || songsToDisplay.length === 0) {
         songsListContainer.innerHTML = '<p>No hay canciones en esta categoría para la década seleccionada.</p>';
@@ -1552,6 +1795,8 @@ let currentOnlinePlayerName = null;
 let isOnlineMode = false;
 let isElderlyMode = false;
 let isSummerSongsMode = false;
+let onlineInvitePollInterval = null;
+let lastInviteCodes = new Set();
 
 // ========== CREAR PARTIDA ONLINE ==========
 async function createOnlineGame() {
@@ -1562,6 +1807,10 @@ async function createOnlineGame() {
     if (!playerData || !playerData.email || !playerData.playerName) {
         alert("Debes iniciar sesión con tu nombre de jugador para crear partidas online.");
         showScreen('login-screen'); // <-- Redirigir a login si no está logueado
+        return;
+    }
+    if (isPremiumSelection(decade, category) && !hasPremiumAccess()) {
+        showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
         return;
     }
 
@@ -1600,7 +1849,7 @@ async function createOnlineGame() {
     }));
 
             alert(`Partida creada con éxito. Comparte este código con tu amigo: ${currentOnlineGameCode}`);
-            startOnlineGame();
+            await startOnlineGame();
         } else {
             alert(result.message || 'Error al crear la partida.');
         }
@@ -1646,7 +1895,7 @@ async function joinOnlineGame() {
                 decade: result.game.decade, // <-- AÑADE ESTO
                 category: result.game.category // <-- AÑADE ESTO
             }));
-            startOnlineGame();
+            await startOnlineGame();
         } else {
             alert(result.message || 'Error al unirse a la partida.');
         }
@@ -1658,7 +1907,6 @@ async function joinOnlineGame() {
 
 // main.js - AÑADE ESTA NUEVA FUNCIÓN COMPLETA
 // Nueva función para unirse a una partida pendiente (reutiliza lógica de joinOnlineGame)
-// main.js - Función joinOnlineGameFromPending (VERIFICAR ESTA LÍNEA)
 async function joinOnlineGameFromPending(code, playerName, email) {
     try {
         const response = await fetch(`${API_BASE_URL}/api/online-games/join`, {
@@ -1675,7 +1923,7 @@ async function joinOnlineGameFromPending(code, playerName, email) {
         if (response.ok) {
             // Si la unión es exitosa, establece las variables de juego online
             currentOnlineGameCode = code;
-            currentOnlineSongs = result.game.songsUsed; // <-- VERIFICA ESTA LÍNEA. Si el server devuelve { game: {...} }, entonces es result.game.songsUsed
+            currentOnlineSongs = result.game.songsUsed;
             currentOnlineEmail = email;
             currentOnlinePlayerName = playerName;
             isOnlineMode = true;
@@ -1683,12 +1931,12 @@ async function joinOnlineGameFromPending(code, playerName, email) {
             // Guardar info del juego online para usarla en startOnlineGame
             localStorage.setItem('currentOnlineGameData', JSON.stringify({
                 code: code,
-                songsUsed: result.game.songsUsed, // <-- VERIFICA ESTA LÍNEA
+                songsUsed: result.game.songsUsed,
                 decade: result.game.decade,
                 category: result.game.category
             }));
 
-            startOnlineGame(); // Inicia el juego
+            await startOnlineGame(); // Inicia el juego
         } else {
             alert(result.message || 'Error al unirse a la partida pendiente.');
             loadPlayerOnlineGames(); // Recarga la lista por si el estado cambió
@@ -1709,7 +1957,7 @@ async function getSongsForOnlineMatch(decade, category) {
 
 // ========== EMPEZAR PARTIDA ONLINE ==========
 // main.js - startOnlineGame
-function startOnlineGame() {
+async function startOnlineGame() {
     // Reiniciar el gameState para una partida online
     gameState = {
         players: [],
@@ -1752,7 +2000,14 @@ function startOnlineGame() {
         showScreen('online-mode-screen');
         return;
     }
-
+    try {
+        await loadSongsForDecadeAndCategory(gameState.selectedDecade, gameState.category);
+    } catch (error) {
+        console.error('Error al cargar las canciones para la partida online:', error);
+        alert('Error al cargar las canciones para la partida online. Intenta de nuevo más tarde.');
+        showScreen('online-mode-screen');
+        return;
+    }
 
     setupQuestion();
     showScreen('game-screen');
@@ -1841,34 +2096,8 @@ function populateOnlineSelectors() {
     const decadeSelect = document.getElementById('online-decade-select');
     const categorySelect = document.getElementById('online-category-select');
 
-    const decades = ['80s', '90s', '00s', '10s', 'Actual'];
-    const categories = [
-        { value: 'espanol', text: 'Canciones en Español' },
-        { value: 'ingles', text: 'Canciones en Inglés' },
-        { value: 'peliculas', text: 'Bandas Sonoras de Películas' },
-        { value: 'series', text: 'Intros de Series' },
-        { value: 'infantiles', text: 'Series y Programas Infantiles' },
-        { value: 'anuncios', text: 'Anuncios de TV' },
-        { value: 'tv', text: 'Programas de Televisión' }
-    ];
-
-    // Limpiar y añadir décadas
-    decadeSelect.innerHTML = '';
-    decades.forEach(dec => {
-        const option = document.createElement('option');
-        option.value = dec;
-        option.textContent = dec;
-        decadeSelect.appendChild(option);
-    });
-
-    // Limpiar y añadir categorías
-    categorySelect.innerHTML = '';
-    categories.forEach(cat => {
-        const option = document.createElement('option');
-        option.value = cat.value;
-        option.textContent = cat.text;
-        categorySelect.appendChild(option);
-    });
+    populateDecadeOptions(decadeSelect, DECADES_ORDER);
+    populateCategoryOptions(categorySelect, CATEGORY_ORDER);
 }
 
 async function saveOnlineGameToHistory(gameData) {
@@ -1904,32 +2133,8 @@ function populateInviteSelectors() {
     const decadeSelect = document.getElementById('invite-decade-select');
     const categorySelect = document.getElementById('invite-category-select');
 
-    const decades = ['80s', '90s', '00s', '10s', 'Actual'];
-    const categories = [
-        { value: 'espanol', text: 'Canciones en Español' },
-        { value: 'ingles', text: 'Canciones en Inglés' },
-        { value: 'peliculas', text: 'Bandas Sonoras de Películas' },
-        { value: 'series', text: 'Intros de Series' },
-        { value: 'infantiles', text: 'Series y Programas Infantiles' },
-        { value: 'anuncios', text: 'Anuncios de TV' },
-        { value: 'tv', text: 'Programas de Televisión' }
-    ];
-
-    decadeSelect.innerHTML = '';
-    decades.forEach(dec => {
-        const option = document.createElement('option');
-        option.value = dec;
-        option.textContent = dec;
-        decadeSelect.appendChild(option);
-    });
-
-    categorySelect.innerHTML = '';
-    categories.forEach(cat => {
-        const option = document.createElement('option');
-        option.value = cat.value;
-        option.textContent = cat.text;
-        categorySelect.appendChild(option);
-    });
+    populateDecadeOptions(decadeSelect, DECADES_ORDER);
+    populateCategoryOptions(categorySelect, CATEGORY_ORDER);
 }
 
 async function invitePlayerByName() {
@@ -1941,6 +2146,10 @@ async function invitePlayerByName() {
     if (!rivalName || !playerData || !playerData.email || !playerData.playerName) {
         alert("Faltan datos o no estás logueado con un nombre de jugador.");
         showScreen('login-screen'); // <-- Redirigir a login si no está logueado
+        return;
+    }
+    if (isPremiumSelection(decade, category) && !hasPremiumAccess()) {
+        showPremiumModal('Contenido premium. Próximamente disponible mediante desbloqueo.');
         return;
     }
 
@@ -1980,6 +2189,7 @@ async function invitePlayerByName() {
                 decade: decade,
                 category: category
             }));
+            await startOnlineGame();
 
         } else {
             alert(result.message || "Error al invitar.");
@@ -2018,6 +2228,16 @@ async function loadPlayerOnlineGames() {
 
         const activeGames = games.filter(game => !game.finished);
         const finishedGames = games.filter(game => game.finished);
+        const pendingInvites = activeGames.filter(game =>
+            game.waitingFor === playerData.email &&
+            game.players.every(p => p.email !== playerData.email)
+        );
+
+        updateOnlineInviteBadge(pendingInvites.length);
+
+        if (!document.getElementById('pending-games-screen')?.classList.contains('active')) {
+            showInviteToast(pendingInvites, playerData.playerName);
+        }
 
         // Renderizar partidas activas
         if (activeGames.length > 0) {
@@ -2058,7 +2278,7 @@ async function loadPlayerOnlineGames() {
 
                 gameDiv.innerHTML = `
                     <p><strong>Partida con:</strong> ${isCreator ? otherPlayerName : invitingPlayerName}</p>
-                    <p><strong>Categoría:</strong> ${decadeNames[game.decade]} - ${categoryNames[game.category]}</p>
+                    <p><strong>Categoría:</strong> ${getDecadeLabel(game.decade)} - ${getCategoryLabel(game.category)}</p>
                     <p><strong>Estado:</strong> ${statusText}</p>
                     ${buttonHtml}
                 `;
@@ -2082,7 +2302,7 @@ async function loadPlayerOnlineGames() {
 
                 gameDiv.innerHTML = `
                     <p><strong>Partida con:</strong> ${isCreator ? otherPlayerName : invitingPlayerName}</p>
-                    <p><strong>Categoría:</strong> ${decadeNames[game.decade]} - ${categoryNames[game.category]}</p>
+                    <p><strong>Categoría:</strong> ${getDecadeLabel(game.decade)} - ${getCategoryLabel(game.category)}</p>
                     <p><strong>Estado:</strong> FINALIZADA</p>
                     <button class="btn" onclick="viewOnlineGameResults('${game.code}')">Ver Resultados</button>
                 `;
@@ -2097,6 +2317,100 @@ async function loadPlayerOnlineGames() {
         document.getElementById('active-games-list').innerHTML = "<p>Error al cargar tus partidas activas.</p>";
         document.getElementById('finished-games-list').innerHTML = "<p>Error al cargar tus partidas finalizadas.</p>";
     }
+}
+
+function updateOnlineInviteBadge(count) {
+    const badge = document.getElementById('online-invite-count');
+    if (!badge) return;
+
+    if (count > 0) {
+        badge.textContent = count;
+        badge.hidden = false;
+    } else {
+        badge.hidden = true;
+    }
+}
+
+function showInviteToast(invites) {
+    if (!invites || invites.length === 0) return;
+
+    const newInvites = invites.filter(invite => !lastInviteCodes.has(invite.code));
+    if (newInvites.length === 0) return;
+
+    newInvites.forEach(invite => lastInviteCodes.add(invite.code));
+
+    const invite = newInvites[0];
+    const invitingPlayerName = invite.players[0] ? invite.players[0].name : 'Alguien';
+    sendInviteNotification(invitingPlayerName);
+    const toast = document.createElement('div');
+    toast.className = 'invite-toast';
+    toast.innerHTML = `
+        <p>¡Nueva invitación de <strong>${invitingPlayerName}</strong>!</p>
+        <button class="btn" type="button">Ver partidas recibidas</button>
+    `;
+
+    const button = toast.querySelector('button');
+    button.addEventListener('click', () => {
+        toast.remove();
+        showScreen('pending-games-screen');
+    });
+
+    document.body.appendChild(toast);
+
+    setTimeout(() => {
+        toast.classList.add('hide');
+        setTimeout(() => toast.remove(), 200);
+    }, 6000);
+}
+
+function requestInviteNotificationPermission() {
+    if (!('Notification' in window)) return;
+
+    const dismissed = localStorage.getItem('inviteNotificationsDismissed');
+    if (dismissed === 'true' || Notification.permission !== 'default') {
+        return;
+    }
+
+    const allowed = confirm('¿Quieres recibir notificaciones cuando tengas invitaciones online?');
+    if (!allowed) {
+        localStorage.setItem('inviteNotificationsDismissed', 'true');
+        return;
+    }
+
+    Notification.requestPermission().catch(error => {
+        console.warn('No se pudo solicitar permiso de notificaciones:', error);
+    });
+}
+
+function sendInviteNotification(invitingPlayerName) {
+    if (!('Notification' in window)) return;
+    if (Notification.permission !== 'granted') return;
+
+    const notification = new Notification('Nueva invitación online', {
+        body: `Te ha invitado ${invitingPlayerName}.`,
+        icon: 'img/adivina.png'
+    });
+
+    notification.onclick = () => {
+        window.focus();
+        showScreen('pending-games-screen');
+        notification.close();
+    };
+}
+
+function startOnlineInvitePolling() {
+    if (onlineInvitePollInterval) return;
+    onlineInvitePollInterval = setInterval(() => {
+        if (currentUser && currentUser.email) {
+            loadPlayerOnlineGames();
+        }
+    }, 15000);
+}
+
+function stopOnlineInvitePolling() {
+    if (!onlineInvitePollInterval) return;
+    clearInterval(onlineInvitePollInterval);
+    onlineInvitePollInterval = null;
 }
 
 // main.js - AÑADE ESTAS NUEVAS FUNCIONES
@@ -2210,7 +2524,7 @@ async function continueOnlineGame(code, playerName, email) {
                 });
             }
 
-            startOnlineGame(); // Inicia el juego con los datos cargados
+            await startOnlineGame(); // Inicia el juego con los datos cargados
         } else {
             alert(result.message || 'Error al cargar la partida para continuar.');
             loadPlayerOnlineGames(); // Recargar la lista por si el estado cambió
@@ -2313,6 +2627,7 @@ window.onload = async () => {
         if (userDataString) {
             const storedUser = JSON.parse(userDataString);
             currentUser = storedUser;
+            getUserPermissions(currentUser.email);
 
             await loadUserScores(currentUser.email);
             await loadGameHistory(currentUser.email);
@@ -2320,6 +2635,7 @@ window.onload = async () => {
             if (currentUser.playerName) {
                 showScreen('decade-selection-screen');
                 generateDecadeButtons();
+                updatePremiumButtonsState();
             } else {
                 showScreen('set-player-name-screen');
             }
@@ -2330,4 +2646,5 @@ window.onload = async () => {
     window.showStatisticsScreen = showStatisticsScreen;
     window.showSongsListCategorySelection = showSongsListCategorySelection;
     window.showOnlineMenu = showOnlineMenu;
+    startOnlineInvitePolling();
 };

--- a/frontend/js/songs-loader.js
+++ b/frontend/js/songs-loader.js
@@ -8,6 +8,9 @@ const allPossibleCategories = ['espanol', 'ingles', 'peliculas', 'series', 'tv',
 // Las décadas que esperamos (ajustado a tus décadas existentes)
 const allDecadesDefined = ['80s', '90s', '00s', '10s', 'actual', 'verano']; // <-- AÑADE 'verano'
 
+window.allPossibleCategories = allPossibleCategories;
+window.allDecadesDefined = allDecadesDefined;
+
 /**
  * Carga las canciones para una década y categoría específica desde un archivo JS.
  * Si la década es 'Todas', llama a loadAllSongs().

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Adivina la Canción",
+  "short_name": "Adivina",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#1b0b2c",
+  "theme_color": "#3b1b52",
+  "lang": "es",
+  "icons": [
+    {
+      "src": "img/adivina.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'adivina-cancion-v1';
+const PRECACHE_URLS = [
+  './',
+  './index.html',
+  './manifest.json',
+  './css/style.css',
+  './js/main.js',
+  './js/songs-loader.js',
+  './img/adivina.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => (key === CACHE_NAME ? null : caches.delete(key)))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(cachedResponse => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request).then(response => {
+        const responseClone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
### Motivation
- Corregir que desde la pantalla de resultados y la pantalla de espera online no había un botón para volver al menú online y que el botón existente llevaba a la pantalla principal en lugar del menú online. 
- Añadir una opción explícita para volver al menú principal desde las pantallas online para mayor claridad del flujo. 
- Aprovechar la oportunidad para mejorar la experiencia de usuario en el frontend (notificaciones, modales, PWA, accesibilidad y estilos). 

### Description
- Cambiado `frontend/index.html` para añadir un botón `Volver al Menú Online` en `online-wait-screen` y `end-game-screen`, y un botón `Menú Principal` separado en ambas pantallas. 
- Añadida la función `goToOnlineMenu()` en `frontend/js/main.js` para resetear el estado online y navegar de forma segura a `online-mode-screen`, y refactorizados varios puntos que llaman a `startOnlineGame()` para usar `await` cuando corresponde. 
- Implementadas mejoras en `main.js`: badge de invitaciones, toast de invitación, petición/permisos de notificaciones, polling de invitaciones, bloqueo de contenido premium con modales (`premium-modal`, `instructions-modal`), toggle de visibilidad de contraseña y otras mejoras de UX (mensajes, etiquetas y textos). 
- Añadidos soporte PWA mínimo con `manifest.json` y `sw.js`, y numerosos cambios de estilo y estructura en `css/style.css` y `index.html` (nuevos modales, botones, iconos y microajustes visuales). 
- Actualizado `js/songs-loader.js` para exponer `allDecadesDefined` y `allPossibleCategories` y asegurar la carga/consolidación de las canciones (soporte para la década `verano` y la opción `Todas`). 

### Testing
- Levantado un servidor local con `python -m http.server 8000` y verificada la app en el navegador; la servidor quedó accesible sin errores. (éxito). 
- Ejecutado un script de Playwright que cargó `index.html`, mostró `online-wait-screen` y `end-game-screen` y capturó capturas en `artifacts/online-wait-buttons.png` y `artifacts/end-game-buttons.png`; las capturas se generaron correctamente (éxito). 
- No se añadieron tests unitarios automatizados adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a822959e4832f8ba9549f89a115cb)