### PR TITLE
Fix start screen navigation regression

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1071,17 +1071,11 @@ function showScreen(screenId) {
     });
     document.getElementById(screenId).classList.add('active');
 
-    const currentPassword = document.getElementById('password-change-current')?.value.trim();
-    const newPassword = document.getElementById('password-change-new')?.value.trim();
-    const confirmPassword = document.getElementById('password-change-confirm')?.value.trim();
-
-    if (!currentPassword || !newPassword) {
-        showAppAlert('Completa todos los campos para cambiar la contraseña.');
-        return;
+    if (screenId === 'create-online-screen') {
+        populateOnlineSelectors();
     }
-    if (newPassword !== confirmPassword) {
-        showAppAlert('Las contraseñas no coinciden.');
-        return;
+    if (screenId === 'invite-online-screen') {
+        populateInviteSelectors();
     }
     if (screenId === 'decade-selection-screen') {
         updatePremiumButtonsState();


### PR DESCRIPTION
### Motivation
- La navegación entre pantallas quedaba bloqueada porque `showScreen` validaba campos de cambio de contraseña, impidiendo que el botón de inicio y pantallas online se abrieran correctamente.

### Description
- Se eliminó la validación de los campos `password-change-*` dentro de `showScreen` y se restauró la inicialización de los selectores online llamando a `populateOnlineSelectors()` para `create-online-screen` y a `populateInviteSelectors()` para `invite-online-screen` en `public/js/main.js`.

### Testing
- No se han ejecutado pruebas automatizadas sobre este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9a5b7ce0832fb170f202ec7ede90)