### PR TITLE
Use CommonJS server entrypoint; add local API fallback and relative asset paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "server.js",
+  "main": "server.cjs",
   "scripts": {
-    "start": "node server.js",
+    "start": "node server.cjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/public/index.html
+++ b/public/index.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Adivina la Canción</title>
     <meta name="theme-color" content="#3b1b52">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Nunito:wght@400;700&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="/css/style.css"> 
+    <link rel="stylesheet" href="css/style.css"> 
 </head>
 <body>
     <button class="hamburger-btn" type="button" onclick="toggleHamburgerMenu()" aria-label="Abrir menú">☰</button>
     <div id="home-screen" class="screen active">
-        <img src="/img/adivina.png" alt="Logotipo de Adivina la Canción" class="logo">
+        <img src="img/adivina.png" alt="Logotipo de Adivina la Canción" class="logo">
         <button class="btn" onclick="showScreen('login-screen')">Jugar</button>
     </div>
 
@@ -228,7 +228,7 @@
     </div>
 
     <div id="elderly-mode-intro-screen" class="screen">
-        <img src="/img/adivina.png" alt="Logotipo de Adivina la Canción" class="logo">
+        <img src="img/adivina.png" alt="Logotipo de Adivina la Canción" class="logo">
         <h2>Modo Fácil</h2>
         <p class="small-text">Bienvenido al juego simplificado. Introduce los nombres de los jugadores.</p>
         <input type="text" id="elderly-player-1-name" class="text-input" placeholder="Nombre del Jugador 1">
@@ -448,7 +448,7 @@
         </div>
     </div>
 
-    <script src="/js/songs-loader.js"></script>
-    <script src="/js/main.js"></script>
+    <script src="js/songs-loader.js"></script>
+    <script src="js/main.js"></script>
 </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "Adivina la Canción",
   "short_name": "Adivina",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#1b0b2c",
   "theme_color": "#3b1b52",
   "lang": "es",
   "icons": [
     {
-      "src": "/img/adivina.png",
+      "src": "img/adivina.png",
       "sizes": "1024x1024",
       "type": "image/png",
       "purpose": "any maskable"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'adivina-cancion-v3';
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/css/style.css',
-  '/js/main.js',
-  '/js/songs-loader.js',
-  '/img/adivina.png'
+  './',
+  'index.html',
+  'manifest.json',
+  'css/style.css',
+  'js/main.js',
+  'js/songs-loader.js',
+  'img/adivina.png'
 ];
 
 self.addEventListener('install', event => {

--- a/server.cjs
+++ b/server.cjs
@@ -1,15 +1,14 @@
-import express from "express";
-import path from "path";
-import { fileURLToPath } from "url";
+require("dotenv").config();
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const express = require("express");
+const path = require("path");
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 // Servir frontend
 app.use(express.static(path.join(__dirname, "public")));
+app.use("/data", express.static(path.join(__dirname, "data")));
 
 // API (solo endpoints específicos)
 app.get("/api/health", (req, res) => {
@@ -24,5 +23,3 @@ app.use((req, res) => {
 app.listen(PORT, () => {
   console.log(`Servidor escuchando en el puerto ${PORT}`);
 });
-
-


### PR DESCRIPTION
### Motivation
- Fix a startup failure on Railway caused by an ESM/CommonJS mismatch so `require` works in the server entrypoint. 
- Make the web app usable when the external API is unreachable by providing a local/offline fallback for authentication, scores and game history. 
- Ensure static assets, service worker precache, manifest and dynamic song data load correctly when the app is served from `/public` or a subpath. 

### Description
- Rename the server entrypoint to `server.cjs`, reference it from `package.json` (`main` and `start`) and serve static `/data` files from the server. 
- Replace absolute-leading-slash asset paths with relative paths in `public/index.html`, `public/manifest.json`, and register the service worker with a relative path to support subpaths. 
- Update `public/sw.js` precache URLs to relative paths. 
- Set `API_BASE_URL` to `window.location.origin` and implement a `useLocalApiFallback` local-storage-backed fallback in `public/js/main.js` with helper functions `getLocalUsers`, `saveLocalUsers`, `getLocalScores`, `saveLocalScores`, `getLocalGameHistory`, `saveLocalGameHistory`, and `parseJsonResponse`. 
- Modify authentication and profile flows (`registerUser`, `loginUser`, `setPlayerName`) and persistence functions (`loadUserScores`, `saveUserScores`, `loadGameHistory`, `saveGameResult`) to attempt remote API calls and gracefully fall back to local storage on network/server errors. 
- Enhance `public/js/songs-loader.js` to try alternate relative script paths (e.g. `../data/songs/...`) when loading decade/category song files. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd5ec0670832fb6a2ea056bdb5106)