### PR TITLE
Harden login response handling

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -433,6 +433,8 @@ function closeChangePasswordModal() {
         });
 }
 
+window.toggleHamburgerMenu = toggleHamburgerMenu;
+
 async function requestPasswordReset() {
     const emailInput = document.getElementById('password-reset-email');
     const email = emailInput?.value.trim();
@@ -640,6 +642,10 @@ async function loginUser() {
         const data = await parseJsonResponse(response);
 
         if (response.ok) {
+            if (!data || !data.user || !data.user.email) {
+                showAppAlert('Respuesta inválida del servidor. Intenta de nuevo más tarde.');
+                return;
+            }
             currentUser = { email: data.user.email, playerName: data.user.playerName };
         } else if (response.status === 404 || response.status >= 500) {
             useLocalApiFallback = true;
@@ -3268,4 +3274,4 @@ window.onload = async () => {
     window.showSongsListCategorySelection = showSongsListCategorySelection;
     window.showOnlineMenu = showOnlineMenu;
     startOnlineInvitePolling();
-}};
+};


### PR DESCRIPTION
### Motivation
- Prevent the app from crashing or falling back to local auth when the backend returns an unexpected/partial JSON during login by validating the response before using it.
- Ensure that when the backend indicates a successful login, `userData` is actually saved to `localStorage` and the UI navigates to the correct next screen.

### Description
- Strengthened `loginUser()` to validate the parsed response (`data`) and specifically check for `data.user.email` before assigning `currentUser`, and show an app alert if the server response is invalid.
- Kept the existing fallback logic (`useLocalApiFallback`) for 404/5xx responses and network errors, and preserved the local-login flow when the API is unavailable.
- Ensured the normal success path continues to call `getUserPermissions`, save `loggedInUserEmail` and `userData` to `localStorage`, load scores/history, and navigate to `decade-selection-screen` or `set-player-name-screen` as appropriate.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b84200d0832f9536101e7d089a3f)