### PR TITLE
Fix audio paths, service worker caching, and expose global handlers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -244,8 +244,8 @@
 </div>
 
     <audio id="audio-player"></audio>
-    <audio id="sfx-acierto" src="audio/sfx/acierto.mp3"></audio>
-    <audio id="sfx-error" src="audio/sfx/error.mp3"></audio>
+    <audio id="sfx-acierto" src="/audio/sfx/acierto.mp3"></audio>
+    <audio id="sfx-error" src="/audio/sfx/error.mp3"></audio>
 
     <div id="premium-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="premium-modal-title">
         <div class="modal-content">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -433,6 +433,8 @@ function closeChangePasswordModal() {
         });
 }
 
+window.toggleHamburgerMenu = toggleHamburgerMenu;
+
 async function requestPasswordReset() {
     const emailInput = document.getElementById('password-reset-email');
     const email = emailInput?.value.trim();
@@ -640,6 +642,10 @@ async function loginUser() {
         const data = await parseJsonResponse(response);
 
         if (response.ok) {
+            if (!data || !data.user || !data.user.email) {
+                showAppAlert('Respuesta inválida del servidor. Intenta de nuevo más tarde.');
+                return;
+            }
             currentUser = { email: data.user.email, playerName: data.user.playerName };
         } else if (response.status === 404 || response.status >= 500) {
             useLocalApiFallback = true;
@@ -1593,7 +1599,7 @@ function playAudioSnippet() {
         showAppAlert("Error al reproducir el audio de la canción. Por favor, revisa la consola para más detalles.");
         return; 
     }
-    audioPlayer.src = `audio/${currentQuestion.originalDecade}/${currentQuestion.originalCategory}/${currentQuestion.file}`;
+    audioPlayer.src = `/audio/${currentQuestion.originalDecade}/${currentQuestion.originalCategory}/${currentQuestion.file}`;
 
     audioPlayer.currentTime = 0;
     audioPlayer.play();
@@ -2716,7 +2722,8 @@ async function loadPlayerOnlineGames() {
 
     try {
         const response = await fetch(`${API_BASE_URL}/api/online-games/player/${playerData.email}`);
-        const games = await response.json();
+        const data = await parseJsonResponse(response);
+        const games = Array.isArray(data) ? data : (Array.isArray(data?.games) ? data.games : []);
 
         const activeGamesContainer = document.getElementById('active-games-list');
         const finishedGamesContainer = document.getElementById('finished-games-list');
@@ -3230,6 +3237,42 @@ window.showAllSongs = showAllSongs;
 window.showOnlineMenu = showOnlineMenu;
 window.confirmResetStatistics = confirmResetStatistics;
 
+Object.assign(window, {
+    togglePasswordVisibility,
+    toggleNotificationsPanel,
+    toggleHamburgerMenu,
+    closeHamburgerMenu,
+    showPasswordRecoveryInfo,
+    showChangePasswordModal,
+    showInstructions,
+    closeInstructions,
+    closePremiumModal,
+    closePasswordResetModal,
+    confirmPasswordReset,
+    requestPasswordReset,
+    closeChangePasswordModal,
+    changePassword,
+    loginUser,
+    registerUser,
+    setPlayerName,
+    startSummerSongsGame,
+    showOnlineMenu,
+    createOnlineGame,
+    joinOnlineGame,
+    invitePlayerByName,
+    confirmClearOnlineGameHistory,
+    goToOnlineMenu,
+    endOnlineModeAndGoHome,
+    showSongsListCategorySelection,
+    selectPlayers,
+    startGame,
+    continueToNextPlayerTurn,
+    confirmReturnToMenu,
+    addElderlyPlayerInput,
+    startElderlyModeGame,
+    exitGame
+});
+
 // =====================================================================
 // INICIALIZACIÓN
 // =====================================================================
@@ -3268,4 +3311,4 @@ window.onload = async () => {
     window.showSongsListCategorySelection = showSongsListCategorySelection;
     window.showOnlineMenu = showOnlineMenu;
     startOnlineInvitePolling();
-}};
+};

--- a/public/js/songs-loader.js
+++ b/public/js/songs-loader.js
@@ -47,6 +47,7 @@ async function loadSongsForDecadeAndCategory(decade, category) {
     // Para 'verano' y 'consolidated' será: data/songs/verano/consolidated.js
     // Para '80s' y 'espanol' será: data/songs/80s/espanol.js
     const scriptPaths = [
+        `/data/songs/${decade}/${category}.js`,
         `data/songs/${decade}/${category}.js`,
         `../data/songs/${decade}/${category}.js`
     ];

--- a/public/sw.js
+++ b/public/sw.js
@@ -32,6 +32,16 @@ self.addEventListener('fetch', event => {
     return;
   }
 
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.pathname.startsWith('/api/')) {
+    return;
+  }
+
+  if (event.request.headers.get('range') || event.request.destination === 'audio') {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then(cachedResponse => {
       if (cachedResponse) {
@@ -39,6 +49,9 @@ self.addEventListener('fetch', event => {
       }
 
       return fetch(event.request).then(response => {
+        if (!response || !response.ok || response.status !== 200) {
+          return response;
+        }
         const responseClone = response.clone();
         caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
         return response;


### PR DESCRIPTION
### Motivation
- Prevent broken audio and song loading caused by path changes after deployment and SPA-style routes. 
- Avoid Service Worker `cache.put` failures and partial response caching for APIs and audio range requests. 
- Stop runtime `ReferenceError` from HTML `onclick` handlers by ensuring functions are defined on the global `window` object and harden login response handling to avoid invalid authenticated state.

### Description
- Update audio asset references to absolute paths by changing `<audio>` sources in `public/index.html` and the runtime audio assignment in `public/js/main.js` to use `/audio/...` so they resolve correctly in production. 
- Make `public/js/songs-loader.js` try absolute `/data/...` first and add fallback paths so dynamic song scripts load correctly under different route bases. 
- Harden login and online-games parsing in `public/js/main.js` by using `parseJsonResponse(response)`, validating `data.user.email` before assigning `currentUser`, and normalizing the `games` value to an array: `Array.isArray(data) ? data : (Array.isArray(data?.games) ? data.games : [])`. 
- Expose inline handlers and commonly-used functions to the global scope by assigning them to `window` (via `Object.assign(window, { ... })`) so `onclick` attributes in `index.html` no longer throw `ReferenceError`. 
- Update `public/sw.js` fetch handler to skip caching for requests under `/api/`, skip `Range` and audio requests (serve them directly), and only `cache.put` responses that are `ok` and have status `200` to avoid caching partial responses (status `206`).

### Testing
- Automated tests: none were run. 
- Changes were committed and basic static checks (file modifications and successful commit) completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b84200d0832f9536101e7d089a3f)