### PR TITLE
Persist session state and fix startup routing to stop login loop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -244,8 +244,8 @@
 </div>
 
     <audio id="audio-player"></audio>
-    <audio id="sfx-acierto" src="audio/sfx/acierto.mp3"></audio>
-    <audio id="sfx-error" src="audio/sfx/error.mp3"></audio>
+    <audio id="sfx-acierto" src="/audio/sfx/acierto.mp3"></audio>
+    <audio id="sfx-error" src="/audio/sfx/error.mp3"></audio>
 
     <div id="premium-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="premium-modal-title">
         <div class="modal-content">

--- a/public/js/songs-loader.js
+++ b/public/js/songs-loader.js
@@ -47,6 +47,7 @@ async function loadSongsForDecadeAndCategory(decade, category) {
     // Para 'verano' y 'consolidated' será: data/songs/verano/consolidated.js
     // Para '80s' y 'espanol' será: data/songs/80s/espanol.js
     const scriptPaths = [
+        `/data/songs/${decade}/${category}.js`,
         `data/songs/${decade}/${category}.js`,
         `../data/songs/${decade}/${category}.js`
     ];

--- a/server.js
+++ b/server.js
@@ -53,13 +53,7 @@ if (!MONGO_URI) {
   process.exit(1);
 }
 
-mongoose
-  .connect(MONGO_URI)
-  .then(() => console.log("Conectado a MongoDB"))
-  .catch((err) => {
-    console.error("Error conectando a MongoDB:", err.message);
-    process.exit(1);
-  });
+mongoose.set("strictQuery", true);
 
 // ==============================
 // 3) Modelos (Mongoose)
@@ -118,6 +112,25 @@ const Score = mongoose.model("Score", scoreSchema);
 const GameHistory = mongoose.model("GameHistory", gameHistorySchema);
 const OnlineGame = mongoose.model("OnlineGame", onlineGameSchema);
 
+async function connectToMongo() {
+  try {
+    await mongoose.connect(MONGO_URI, { serverSelectionTimeoutMS: 5000 });
+    console.log("Conectado a MongoDB");
+
+    await Promise.all([
+      User.createCollection(),
+      Score.createCollection(),
+      GameHistory.createCollection(),
+      OnlineGame.createCollection(),
+    ]);
+    await Promise.all([User.init(), Score.init(), GameHistory.init(), OnlineGame.init()]);
+    console.log("Colecciones e índices verificados.");
+  } catch (err) {
+    console.error("Error conectando a MongoDB:", err.message);
+    throw err;
+  }
+}
+
 // ==============================
 // 4) API
 // ==============================
@@ -138,6 +151,7 @@ app.post("/api/register", async (req, res) => {
     const hashed = await bcrypt.hash(password, salt);
 
     await new User({ email, password: hashed }).save();
+    console.log("Usuario registrado:", email);
     res.status(201).json({ message: "Usuario registrado exitosamente." });
   } catch (err) {
     console.error("Error en registro:", err.message);
@@ -159,6 +173,7 @@ app.post("/api/login", async (req, res) => {
     const ok = await bcrypt.compare(password, user.password);
     if (!ok) return res.status(400).json({ message: "Credenciales inválidas." });
 
+    console.log("Login exitoso:", email);
     res.status(200).json({
       message: "Inicio de sesión exitoso.",
       user: { email: user.email, playerName: user.playerName || null },
@@ -278,7 +293,7 @@ app.get("/api/scores/:email", async (req, res) => {
     res.status(200).json(scores);
   } catch (err) {
     console.error("Error get scores:", err.message);
-    res.status(500).json({ message: "Error del servidor." });
+    res.status(200).json([]);
   }
 });
 
@@ -481,10 +496,11 @@ app.get("/api/online-games/player/:playerEmail", async (req, res) => {
       ],
     }).sort({ createdAt: -1 });
 
-    res.status(200).json(games);
+    console.log("Online games cargadas para:", playerEmail, "total:", games.length);
+    res.status(200).json(Array.isArray(games) ? games : []);
   } catch (err) {
     console.error("Error get player games:", err.message);
-    res.status(500).json({ message: "Error del servidor." });
+    res.status(200).json([]);
   }
 });
 
@@ -537,6 +553,18 @@ app.delete("/api/online-games/clear-history/:playerEmail", async (req, res) => {
 // 5) Frontend (public + data)
 // ==============================
 app.use(express.static(path.join(__dirname, "public")));
+app.use(
+  "/audio",
+  express.static(path.join(__dirname, "public", "audio"), {
+    fallthrough: false,
+    setHeaders: (res, filePath) => {
+      if (filePath.endsWith(".mp3")) {
+        res.setHeader("Content-Type", "audio/mpeg");
+      }
+      res.setHeader("Accept-Ranges", "bytes");
+    },
+  })
+);
 app.use("/data", express.static(path.join(__dirname, "data")));
 
 // Fallback: cualquier ruta que NO empiece por /api/ -> index.html
@@ -544,6 +572,16 @@ app.get(/^\/(?!api).*/, (req, res) => {
   res.sendFile(path.join(__dirname, "public", "index.html"));
 });
 
-app.listen(PORT, () => {
-  console.log(`Servidor escuchando en el puerto ${PORT}`);
-});
+async function startServer() {
+  try {
+    await connectToMongo();
+    app.listen(PORT, () => {
+      console.log(`Servidor escuchando en el puerto ${PORT}`);
+    });
+  } catch (err) {
+    console.error("No se pudo iniciar el servidor:", err.message);
+    process.exit(1);
+  }
+}
+
+startServer();


### PR DESCRIPTION
### Motivation
- Fix the infinite login → set player name → login loop by ensuring session state is persisted across the name flow.  
- Ensure the app startup routing respects session presence and player name so users go to the correct screen.  
- Make small related hardening and PWA/asset-serving adjustments to avoid audio playback/caching issues that could interfere with UX.

### Description
- Persist an explicit `sessionActive` flag in `localStorage` on successful `login` and on player-name updates and clear it on `logout`, and update `logout` to return to the login screen (changes in `public/js/main.js`).
- Change startup routing in `window.onload` to check `sessionActive` plus `userData` and route to `login`, `set-player-name` or main menu accordingly (in `public/js/main.js`).
- Ensure saving a player name does not invalidate the session by keeping `sessionActive` set when updating the name (in `public/js/main.js`).
- Use absolute `/audio/...` URLs for audio assets and update `songs-loader` fallback paths to try `/data/...` first to avoid Service Worker/cache/route mismatches (changes in `public/index.html`, `public/js/main.js`, and `public/js/songs-loader.js`).
- Update the Service Worker to bypass caching/interception for audio files, `Range` requests and `/api/` routes so audio streaming and partial requests work reliably (change in `public/sw.js`).
- Add explicit audio static serving in the backend with correct headers (`Content-Type: audio/mpeg`, `Accept-Ranges: bytes`) and harden server startup by deferring `app.listen` until `connectToMongo()` succeeds and collections/indexes are initialized (changes in `server.js`).
- Minor backend resiliency changes: add logging and return empty arrays on some read errors to avoid frontend failures (changes in `server.js`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b84200d0832f9536101e7d089a3f)