### PR TITLE
Add social sharing buttons to end-game results (WhatsApp, Facebook, Instagram, X)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,6 +107,70 @@ h1 {
     border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
+.share-section {
+    margin: 20px 0;
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 234, 255, 0.4);
+    background: rgba(0, 0, 0, 0.25);
+    box-shadow: var(--shadow-base);
+}
+
+.share-title {
+    margin-bottom: 12px;
+    font-weight: 700;
+    color: var(--secondary-color);
+}
+
+.share-buttons {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-decoration: none;
+    color: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--shadow-base);
+    transition: transform .2s, box-shadow .2s;
+}
+
+.share-btn svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.share-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0 10px var(--secondary-color);
+}
+
+.share-btn.whatsapp {
+    background: #25d366;
+}
+
+.share-btn.facebook {
+    background: #1877f2;
+}
+
+.share-btn.instagram {
+    background: linear-gradient(45deg, #feda75, #fa7e1e, #d62976, #962fbf, #4f5bd5);
+}
+
+.share-btn.x-network {
+    background: #111111;
+}
+
 .btn:hover, .category-btn:hover, .player-btn:hover {
     transform: translateY(-3px);
     box-shadow: 0 0 10px var(--primary-color), 0 0 18px var(--secondary-color);

--- a/public/index.html
+++ b/public/index.html
@@ -221,6 +221,36 @@
         <h2>Partida Terminada</h2>
         <div id="winner-display"></div>
         <div id="final-scores"></div>
+        <div class="share-section" aria-live="polite">
+            <p class="share-title">Compartir resultado</p>
+            <div class="share-buttons">
+                <a class="share-btn whatsapp" id="share-whatsapp" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en WhatsApp">
+                    <svg viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+                        <path d="M19.11 17.39c-.27-.14-1.59-.79-1.84-.88-.25-.09-.43-.14-.61.14-.18.27-.7.88-.86 1.06-.16.18-.32.2-.59.07-.27-.14-1.14-.42-2.17-1.34-.8-.71-1.34-1.6-1.5-1.87-.16-.27-.02-.42.12-.56.12-.12.27-.32.41-.48.14-.16.18-.27.27-.45.09-.18.05-.34-.02-.48-.07-.14-.61-1.48-.84-2.03-.22-.53-.44-.46-.61-.46h-.52c-.18 0-.48.07-.73.34s-.96.93-.96 2.27.99 2.64 1.13 2.82c.14.18 1.95 2.98 4.73 4.18.66.29 1.17.46 1.57.59.66.21 1.26.18 1.74.11.53-.08 1.59-.65 1.81-1.28.22-.63.22-1.17.16-1.28-.06-.11-.23-.18-.5-.32zM16.06 5.33c-5.7 0-10.33 4.63-10.33 10.33 0 1.81.48 3.58 1.39 5.13L5.6 26.67l6.04-1.59a10.3 10.3 0 0 0 4.42.99c5.7 0 10.33-4.63 10.33-10.33S21.76 5.33 16.06 5.33zm0 19.01a8.6 8.6 0 0 1-4.39-1.2l-.31-.18-3.58.94.96-3.48-.2-.36a8.63 8.63 0 1 1 7.52 4.28z"/>
+                    </svg>
+                    <span>WhatsApp</span>
+                </a>
+                <a class="share-btn facebook" id="share-facebook" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en Facebook">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9v-2.9h2.5V9.4c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.5v1.8h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/>
+                    </svg>
+                    <span>Facebook</span>
+                </a>
+                <a class="share-btn instagram" id="share-instagram" href="https://www.instagram.com/" target="_blank" rel="noopener noreferrer" aria-label="Compartir en Instagram">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M12 7.3a4.7 4.7 0 1 0 0 9.4 4.7 4.7 0 0 0 0-9.4zm0 7.7a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm5.9-7.9a1.1 1.1 0 1 1-2.2 0 1.1 1.1 0 0 1 2.2 0z"/>
+                        <path d="M16.9 3H7.1C4.8 3 3 4.8 3 7.1v9.8C3 19.2 4.8 21 7.1 21h9.8c2.3 0 4.1-1.8 4.1-4.1V7.1C21 4.8 19.2 3 16.9 3zm2.4 13.9c0 1.3-1.1 2.4-2.4 2.4H7.1c-1.3 0-2.4-1.1-2.4-2.4V7.1c0-1.3 1.1-2.4 2.4-2.4h9.8c1.3 0 2.4 1.1 2.4 2.4v9.8z"/>
+                    </svg>
+                    <span>Instagram</span>
+                </a>
+                <a class="share-btn x-network" id="share-x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en X">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M18.9 3H22l-6.6 7.5L22.8 21H17l-4.5-6-5.2 6H4l7.1-8.1L1.7 3h6l4.1 5.4L18.9 3zm-1.3 16h1.7L7.3 5H5.5l12.1 14z"/>
+                    </svg>
+                    <span>X</span>
+                </a>
+            </div>
+        </div>
         <button class="btn" id="play-again-btn">Volver a Jugar</button>
         <button class="btn secondary" id="back-to-categories-btn" type="button">Volver a Categorías</button>
         <button class="btn secondary" id="back-to-decades-btn" type="button">Volver a Décadas</button>


### PR DESCRIPTION
### Motivation

- Añadir la opción de compartir los resultados de un duelo por WhatsApp y redes sociales (Facebook, Instagram, X) tanto para partidas locales como online.

### Description

- Añadida la sección de compartir en la pantalla de fin de partida en `public/index.html` con botones y SVGs para `WhatsApp`, `Facebook`, `Instagram` y `X`.
- Nuevos estilos para el bloque de compartir y botones en `public/css/style.css` para integrarlos con la estética existente.
- Implementadas las funciones `buildSharePayload`, `updateShareLinks` e `initializeShareButtons` en `public/js/main.js`, y llamadas a `updateShareLinks(...)` desde `endGame()` y `showOnlineResults()` para generar enlaces (WhatsApp, Facebook, X) y usar `navigator.share` como fallback nativo para Instagram cuando esté disponible.
- Se inicializa `initializeShareButtons()` en `window.onload` para habilitar el comportamiento interactivo de los botones.

### Testing

- Smoke test automatizado: se levantó un servidor estático (`python -m http.server`) y se ejecutó un script de Playwright para mostrar la pantalla `end-game-screen`, inyectar datos de ejemplo y capturar la pantalla, generando `artifacts/end-game-share.png`; este test E2E de integración visual se completó con éxito.
- No se ejecutaron tests unitarios adicionales ni linters automáticos durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697110695e24832fad4aea8aa3483170)