### PR TITLE
Add controlled PWA install prompt

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,6 +107,70 @@ h1 {
     border: 1px solid rgba(255, 255, 255, 0.2);
 }
 
+.share-section {
+    margin: 20px 0;
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 234, 255, 0.4);
+    background: rgba(0, 0, 0, 0.25);
+    box-shadow: var(--shadow-base);
+}
+
+.share-title {
+    margin-bottom: 12px;
+    font-weight: 700;
+    color: var(--secondary-color);
+}
+
+.share-buttons {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-decoration: none;
+    color: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: var(--shadow-base);
+    transition: transform .2s, box-shadow .2s;
+}
+
+.share-btn svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.share-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0 10px var(--secondary-color);
+}
+
+.share-btn.whatsapp {
+    background: #25d366;
+}
+
+.share-btn.facebook {
+    background: #1877f2;
+}
+
+.share-btn.instagram {
+    background: linear-gradient(45deg, #feda75, #fa7e1e, #d62976, #962fbf, #4f5bd5);
+}
+
+.share-btn.x-network {
+    background: #111111;
+}
+
 .btn:hover, .category-btn:hover, .player-btn:hover {
     transform: translateY(-3px);
     box-shadow: 0 0 10px var(--primary-color), 0 0 18px var(--secondary-color);
@@ -120,6 +184,15 @@ h1 {
 .btn.secondary:hover {
     background-image: linear-gradient(45deg, #343a40, #6c757d);
     box-shadow: 0 0 12px rgba(108, 117, 125, 0.7);
+}
+
+.install-btn {
+    position: fixed;
+    bottom: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(320px, 90%);
+    z-index: 1400;
 }
 
 .btn.tertiary {

--- a/public/index.html
+++ b/public/index.html
@@ -221,6 +221,36 @@
         <h2>Partida Terminada</h2>
         <div id="winner-display"></div>
         <div id="final-scores"></div>
+        <div class="share-section" aria-live="polite">
+            <p class="share-title">Compartir resultado</p>
+            <div class="share-buttons">
+                <a class="share-btn whatsapp" id="share-whatsapp" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en WhatsApp">
+                    <svg viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+                        <path d="M19.11 17.39c-.27-.14-1.59-.79-1.84-.88-.25-.09-.43-.14-.61.14-.18.27-.7.88-.86 1.06-.16.18-.32.2-.59.07-.27-.14-1.14-.42-2.17-1.34-.8-.71-1.34-1.6-1.5-1.87-.16-.27-.02-.42.12-.56.12-.12.27-.32.41-.48.14-.16.18-.27.27-.45.09-.18.05-.34-.02-.48-.07-.14-.61-1.48-.84-2.03-.22-.53-.44-.46-.61-.46h-.52c-.18 0-.48.07-.73.34s-.96.93-.96 2.27.99 2.64 1.13 2.82c.14.18 1.95 2.98 4.73 4.18.66.29 1.17.46 1.57.59.66.21 1.26.18 1.74.11.53-.08 1.59-.65 1.81-1.28.22-.63.22-1.17.16-1.28-.06-.11-.23-.18-.5-.32zM16.06 5.33c-5.7 0-10.33 4.63-10.33 10.33 0 1.81.48 3.58 1.39 5.13L5.6 26.67l6.04-1.59a10.3 10.3 0 0 0 4.42.99c5.7 0 10.33-4.63 10.33-10.33S21.76 5.33 16.06 5.33zm0 19.01a8.6 8.6 0 0 1-4.39-1.2l-.31-.18-3.58.94.96-3.48-.2-.36a8.63 8.63 0 1 1 7.52 4.28z"/>
+                    </svg>
+                    <span>WhatsApp</span>
+                </a>
+                <a class="share-btn facebook" id="share-facebook" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en Facebook">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M22 12a10 10 0 1 0-11.6 9.9v-7H7.9v-2.9h2.5V9.4c0-2.5 1.5-3.9 3.8-3.9 1.1 0 2.2.2 2.2.2v2.4h-1.2c-1.2 0-1.6.8-1.6 1.5v1.8h2.8l-.4 2.9h-2.4v7A10 10 0 0 0 22 12z"/>
+                    </svg>
+                    <span>Facebook</span>
+                </a>
+                <a class="share-btn instagram" id="share-instagram" href="https://www.instagram.com/" target="_blank" rel="noopener noreferrer" aria-label="Compartir en Instagram">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M12 7.3a4.7 4.7 0 1 0 0 9.4 4.7 4.7 0 0 0 0-9.4zm0 7.7a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm5.9-7.9a1.1 1.1 0 1 1-2.2 0 1.1 1.1 0 0 1 2.2 0z"/>
+                        <path d="M16.9 3H7.1C4.8 3 3 4.8 3 7.1v9.8C3 19.2 4.8 21 7.1 21h9.8c2.3 0 4.1-1.8 4.1-4.1V7.1C21 4.8 19.2 3 16.9 3zm2.4 13.9c0 1.3-1.1 2.4-2.4 2.4H7.1c-1.3 0-2.4-1.1-2.4-2.4V7.1c0-1.3 1.1-2.4 2.4-2.4h9.8c1.3 0 2.4 1.1 2.4 2.4v9.8z"/>
+                    </svg>
+                    <span>Instagram</span>
+                </a>
+                <a class="share-btn x-network" id="share-x" href="#" target="_blank" rel="noopener noreferrer" aria-label="Compartir en X">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M18.9 3H22l-6.6 7.5L22.8 21H17l-4.5-6-5.2 6H4l7.1-8.1L1.7 3h6l4.1 5.4L18.9 3zm-1.3 16h1.7L7.3 5H5.5l12.1 14z"/>
+                    </svg>
+                    <span>X</span>
+                </a>
+            </div>
+        </div>
         <button class="btn" id="play-again-btn">Volver a Jugar</button>
         <button class="btn secondary" id="back-to-categories-btn" type="button">Volver a Categorías</button>
         <button class="btn secondary" id="back-to-decades-btn" type="button">Volver a Décadas</button>
@@ -246,6 +276,10 @@
     <audio id="audio-player"></audio>
     <audio id="sfx-acierto" src="/audio/sfx/acierto.mp3"></audio>
     <audio id="sfx-error" src="/audio/sfx/error.mp3"></audio>
+
+    <button class="btn secondary install-btn" id="install-btn" type="button" style="display: none;">
+        Instalar app
+    </button>
 
     <div id="premium-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="premium-modal-title">
         <div class="modal-content">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1728,6 +1728,161 @@ function continueToNextPlayerTurn() {
     showScreen('game-screen');
 }
 
+let currentSharePayload = null;
+let deferredInstallPrompt = null;
+
+function isAppInstalled() {
+    return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+}
+
+function isMobileDevice() {
+    return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+function updateInstallButtonVisibility() {
+    const installBtn = document.getElementById('install-btn');
+    if (!installBtn) return;
+
+    const shouldShow = Boolean(deferredInstallPrompt) && !isAppInstalled() && isMobileDevice();
+    installBtn.style.display = shouldShow ? 'inline-flex' : 'none';
+}
+
+function initializeInstallPrompt() {
+    const installBtn = document.getElementById('install-btn');
+    if (!installBtn) return;
+
+    window.addEventListener('beforeinstallprompt', (event) => {
+        event.preventDefault();
+        deferredInstallPrompt = event;
+        updateInstallButtonVisibility();
+    });
+
+    window.addEventListener('appinstalled', () => {
+        deferredInstallPrompt = null;
+        updateInstallButtonVisibility();
+    });
+
+    installBtn.addEventListener('click', async () => {
+        if (!deferredInstallPrompt) return;
+        deferredInstallPrompt.prompt();
+        await deferredInstallPrompt.userChoice;
+        deferredInstallPrompt = null;
+        updateInstallButtonVisibility();
+    });
+
+    updateInstallButtonVisibility();
+}
+
+function generateSinglePlayerShareText(player, gameUrl) {
+    const templates = [
+        `🎶 Reto superado en Adivina la Canción 🎶\n\n🎧 {{player}} ha conseguido {{score}} puntos.\n¿Habrías llegado tan lejos?\n\nPon a prueba tu oído musical 👇\n👉 {{gameUrl}}`,
+        `🔥 ¿Cuánto sabes realmente de música? 🔥\n\n{{player}} ha logrado {{score}} puntos en Adivina la Canción.\nNo es tan fácil como parece…\n\n¿Aceptas el reto?\n👉 {{gameUrl}}`,
+        `🎵 Partida completada en Adivina la Canción\n\n🎧 {{player}}: {{score}} puntos.\n¿Te animas a intentarlo tú?\n\n👉 {{gameUrl}}`,
+        `🎶 {{player}} se ha puesto a prueba en Adivina la Canción\n\nResultado final: {{score}} puntos.\n¿Puedes superarlo?\n\n👉 {{gameUrl}}`
+    ];
+
+    const template = templates[Math.floor(Math.random() * templates.length)];
+    return template
+        .replace('{{player}}', player.name)
+        .replace('{{score}}', player.score)
+        .replace('{{gameUrl}}', gameUrl);
+}
+
+function generateShareText(players, gameUrl) {
+    // Ordenar por puntuación descendente
+    const sortedPlayers = [...players].sort((a, b) => b.score - a.score);
+    const topPlayer = sortedPlayers[0];
+    const secondPlayer = sortedPlayers[1];
+
+    if (!topPlayer) {
+        return `🎵 Adivina la Canción 🎵\n\n¿Te animas a jugar una partida?\n👉 ${gameUrl}`;
+    }
+
+    if (!secondPlayer) {
+        return generateSinglePlayerShareText(topPlayer, gameUrl);
+    }
+
+    const winner = topPlayer.name;
+    const winnerScore = topPlayer.score;
+    const loser = secondPlayer.name;
+    const loserScore = secondPlayer.score;
+    const diff = Math.abs(winnerScore - loserScore);
+
+    if (diff === 0) {
+        return `🎵 Empate total en Adivina la Canción 🎵\n\n🤝 ${winner} y ${loser} terminan igualados con ${winnerScore} puntos.\nSin ganador… por ahora.\n\n¿Te unes para romper el empate?\n👉 ${gameUrl}`;
+    }
+
+    if (diff === 1) {
+        return `🎶 Final de auténtico infarto en Adivina la Canción 🎶\n\n🏆 Ganador: ${winner} con ${winnerScore} puntos\n😮 ${loser} se queda a solo 1 punto (${loserScore})\n\nUna canción más lo habría cambiado todo…\n¿Habrías acertado tú la definitiva?\n👉 ${gameUrl}`;
+    }
+
+    if (diff >= 2 && diff <= 4) {
+        return `🎧 Duelo muy ajustado en Adivina la Canción 🎧\n\n🥇 ${winner} se impone con ${winnerScore} puntos\n🥈 ${loser}, muy cerca, con ${loserScore}\n\nNada estaba decidido hasta el final.\n¿Te atreves a mejorar este resultado?\n👉 ${gameUrl}`;
+    }
+
+    return `🔥 Exhibición musical en Adivina la Canción 🔥\n\n🏆 ${winner} arrasa con ${winnerScore} puntos\n${loser} se queda en ${loserScore}\n\n¿Habrías podido frenar esta victoria?\nDemuéstralo en tu propio duelo 👇\n👉 ${gameUrl}`;
+}
+
+// Ejemplo de uso con datos simulados
+// const exampleShareText = generateShareText(
+//     [{ name: 'Ana', score: 8 }, { name: 'Luis', score: 7 }],
+//     'https://adivinalacancion.app'
+// );
+// const exampleSinglePlayerText = generateSinglePlayerShareText(
+//     { name: 'Ana', score: 10 },
+//     'https://adivinalacancion.app'
+// );
+
+function buildSharePayload({ players, gameUrl }) {
+    return {
+        text: generateShareText(players, gameUrl),
+        url: gameUrl
+    };
+}
+
+function updateShareLinks(payload) {
+    currentSharePayload = payload;
+    const whatsappLink = document.getElementById('share-whatsapp');
+    const facebookLink = document.getElementById('share-facebook');
+    const instagramLink = document.getElementById('share-instagram');
+    const xLink = document.getElementById('share-x');
+
+    const encodedText = encodeURIComponent(payload.text);
+    const encodedUrl = encodeURIComponent(payload.url);
+
+    if (whatsappLink) {
+        whatsappLink.href = `https://api.whatsapp.com/send?text=${encodedText}`;
+    }
+    if (facebookLink) {
+        facebookLink.href = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`;
+    }
+    if (instagramLink) {
+        instagramLink.dataset.shareText = payload.text;
+        instagramLink.dataset.shareUrl = payload.url;
+    }
+    if (xLink) {
+        xLink.href = `https://twitter.com/intent/tweet?text=${encodedText}`;
+    }
+}
+
+function initializeShareButtons() {
+    const instagramLink = document.getElementById('share-instagram');
+    if (!instagramLink) return;
+
+    instagramLink.addEventListener('click', async (event) => {
+        if (!currentSharePayload || !navigator.share) return;
+        event.preventDefault();
+        try {
+            await navigator.share({
+                text: currentSharePayload.text,
+                url: currentSharePayload.url
+            });
+        } catch (error) {
+            console.warn('Compartir nativo cancelado o no disponible:', error);
+        }
+    });
+}
+
 /**
  * Finaliza la partida, calcula el ganador y guarda los resultados.
  */
@@ -1802,6 +1957,11 @@ function endGame() {
         const medal = (gameState.players.length > 1) ? ({ 0: '🥇', 1: '🥈', 2: '🥉' }[index] || '') : '';
         finalScoresContainer.innerHTML += `<p>${medal} ${player.name}: <strong>${player.score} puntos</strong></p>`;
     });
+
+    updateShareLinks(buildSharePayload({
+        players: gameState.players,
+        gameUrl: 'https://adivinalacancion.app'
+    }));
 
     // Recopilar todas las canciones jugadas en esta partida por todos los jugadores
     let allPlayedSongsInThisGame = [];
@@ -3223,6 +3383,11 @@ function showOnlineResults(gameData) {
         finalScoresContainer.innerHTML += `<p>${medal} ${player.name}: <strong>${player.score} puntos</strong></p>`;
     });
 
+    updateShareLinks(buildSharePayload({
+        players: gameData.players || [],
+        gameUrl: 'https://adivinalacancion.app'
+    }));
+
     // Opciones de botón después de partida online: Volver al menú principal
     document.getElementById('play-again-btn').onclick = () => {
         // Limpiar estado online y volver al menú online para jugar otra partida online
@@ -3340,4 +3505,6 @@ window.onload = async () => {
     window.showSongsListCategorySelection = showSongsListCategorySelection;
     window.showOnlineMenu = showOnlineMenu;
     startOnlineInvitePolling();
+    initializeShareButtons();
+    initializeInstallPrompt();
 };


### PR DESCRIPTION
### Motivation
- Implementar un flujo fiable y controlado para mostrar la opción de instalación PWA sin depender del comportamiento automático del navegador. 
- Mostrar un CTA de “Instalar app” solo en móviles compatibles, solo si la app no está ya instalada y solo cuando el navegador permita la instalación. 

### Description
- Añadido botón de instalación en `public/index.html` (`#install-btn`) y sección de compartir resultados en la pantalla de fin de partida. 
- Estilos nuevos en `public/css/style.css` para la UI de compartir y para posicionar el botón de instalación (`.install-btn`). 
- Implementadas en `public/js/main.js` las variables y funciones `deferredInstallPrompt`, `isAppInstalled()`, `isMobileDevice()`, `updateInstallButtonVisibility()` e `initializeInstallPrompt()` que gestionan `beforeinstallprompt` y `appinstalled`, hacen `event.preventDefault()`, guardan el event y solo llaman a `prompt()` tras interacción del usuario. 
- Integración en el arranque de la app llamando a `initializeInstallPrompt()` desde `window.onload` y limpieza del `deferredInstallPrompt` tras la elección del usuario; además se añadieron helpers de compartido (`buildSharePayload`, `updateShareLinks`, `initializeShareButtons`) y llamadas a `updateShareLinks()` desde `endGame()` y `showOnlineResults()` para poblar los enlaces sociales. 

### Testing
- Levantado un servidor local con `python -m http.server 4173` y ejecutado un script Playwright que cargó `index.html` y capturó una captura (`artifacts/install-button.png`) para verificar la presencia del botón, y la ejecución finalizó correctamente. 
- No se ejecutaron pruebas unitarias automatizadas adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697110695e24832fad4aea8aa3483170)