### PR TITLE
Fix PWA install prompt flow

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1793,9 +1793,11 @@ function initializeInstallPrompt() {
             }
             if (deferredInstallPrompt) {
                 deferredInstallPrompt.prompt();
-                await deferredInstallPrompt.userChoice;
+                const choice = await deferredInstallPrompt.userChoice;
+                if (choice && choice.outcome === 'accepted') {
+                    installBtn.style.display = 'none';
+                }
                 deferredInstallPrompt = null;
-                updateInstallButtonVisibility();
                 return;
             }
             showManualInstallNotice();


### PR DESCRIPTION
### Motivation
- Evitar que Chrome cree un “acceso directo” cuando no existe el evento `beforeinstallprompt` y asegurar que la acción de instalación sólo se lance con un `deferredInstallPrompt` válido.

### Description
- Al hacer clic en el botón `install-btn` ahora sólo se llama a `deferredInstallPrompt.prompt()` si `deferredInstallPrompt` existe, se espera a `deferredInstallPrompt.userChoice` y se oculta el botón cuando el usuario acepta; en el caso contrario se muestra únicamente el modal informativo mediante `showManualInstallNotice()`.

### Testing
- No se ejecutaron tests automatizados durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697215fab580832f8892f7b4d8a47a69)