### PR TITLE
Remove manual install fallback and show neutral availability alert

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1793,12 +1793,14 @@ function initializeInstallPrompt() {
             }
             if (deferredInstallPrompt) {
                 deferredInstallPrompt.prompt();
-                await deferredInstallPrompt.userChoice;
+                const choice = await deferredInstallPrompt.userChoice;
+                if (choice && choice.outcome === 'accepted') {
+                    updateInstallButtonVisibility();
+                }
                 deferredInstallPrompt = null;
-                updateInstallButtonVisibility();
                 return;
             }
-            showManualInstallNotice();
+            showAppAlert('La instalación no está disponible en este momento. Navega un poco más por la app y vuelve a intentarlo.');
         });
         installNoticeInitialized = true;
     }
@@ -1815,29 +1817,6 @@ function initializeInstallPrompt() {
     });
 
     updateInstallButtonVisibility();
-}
-
-function showManualInstallNotice() {
-    let notice = document.getElementById('manual-install-notice');
-    if (!notice) {
-        notice = document.createElement('div');
-        notice.id = 'manual-install-notice';
-        notice.className = 'modal-overlay hidden';
-        notice.innerHTML = `
-            <div class="modal-content">
-                <p>Pulsa ⋮ y selecciona ‘Añadir a pantalla de inicio’</p>
-                <button class="btn secondary" type="button" id="manual-install-close">Cerrar</button>
-            </div>
-        `;
-        document.body.appendChild(notice);
-        const closeBtn = notice.querySelector('#manual-install-close');
-        if (closeBtn) {
-            closeBtn.addEventListener('click', () => {
-                notice.classList.add('hidden');
-            });
-        }
-    }
-    notice.classList.remove('hidden');
 }
 
 function generateSinglePlayerShareText(player, gameUrl, decade, category) {


### PR DESCRIPTION
### Motivation
- Restore real PWA installation behavior by removing any manual fallback that led browsers to create shortcuts instead of a standalone install.
- Ensure the `install-btn` acts only on the presence of a `beforeinstallprompt` event and never triggers browser menu/manual-install flows.
- Keep all changes confined to `public/js/main.js` and avoid introducing new UI elements or forcing installs.

### Description
- Removed the `showManualInstallNotice()` function and its DOM modal so there is no manual “Add to home screen” fallback in `public/js/main.js`.
- Replaced the manual-install invocation with a neutral alert via `showAppAlert('La instalación no está disponible en este momento. Navega un poco más por la app y vuelve a intentarlo.')` when no `deferredInstallPrompt` is available.
- Updated the `install-btn` click handler to call `deferredInstallPrompt.prompt()` only when `deferredInstallPrompt` exists, wait for `userChoice`, and call `updateInstallButtonVisibility()` only if the outcome is `'accepted'`, and then clear `deferredInstallPrompt`.
- Preserved the `beforeinstallprompt` and `appinstalled` handlers and the `updateInstallButtonVisibility()` behavior so the real PWA install flow remains intact.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697215fab580832f8892f7b4d8a47a69)