### PR TITLE
Restore canonical PWA install flow: show install button only when `beforeinstallprompt` exists and remove manual fallback

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1777,7 +1777,7 @@ function updateInstallButtonVisibility() {
     const installBtn = document.getElementById('install-btn');
     if (!installBtn) return;
 
-    const shouldShow = !isAppInstalled();
+    const shouldShow = Boolean(deferredInstallPrompt) && !isAppInstalled();
     installBtn.style.display = shouldShow ? 'inline-flex' : 'none';
 }
 
@@ -1793,12 +1793,13 @@ function initializeInstallPrompt() {
             }
             if (deferredInstallPrompt) {
                 deferredInstallPrompt.prompt();
-                await deferredInstallPrompt.userChoice;
+                const choice = await deferredInstallPrompt.userChoice;
+                if (choice && choice.outcome === 'accepted') {
+                    updateInstallButtonVisibility();
+                }
                 deferredInstallPrompt = null;
-                updateInstallButtonVisibility();
                 return;
             }
-            showManualInstallNotice();
         });
         installNoticeInitialized = true;
     }
@@ -1815,29 +1816,6 @@ function initializeInstallPrompt() {
     });
 
     updateInstallButtonVisibility();
-}
-
-function showManualInstallNotice() {
-    let notice = document.getElementById('manual-install-notice');
-    if (!notice) {
-        notice = document.createElement('div');
-        notice.id = 'manual-install-notice';
-        notice.className = 'modal-overlay hidden';
-        notice.innerHTML = `
-            <div class="modal-content">
-                <p>Pulsa ⋮ y selecciona ‘Añadir a pantalla de inicio’</p>
-                <button class="btn secondary" type="button" id="manual-install-close">Cerrar</button>
-            </div>
-        `;
-        document.body.appendChild(notice);
-        const closeBtn = notice.querySelector('#manual-install-close');
-        if (closeBtn) {
-            closeBtn.addEventListener('click', () => {
-                notice.classList.add('hidden');
-            });
-        }
-    }
-    notice.classList.remove('hidden');
 }
 
 function generateSinglePlayerShareText(player, gameUrl, decade, category) {


### PR DESCRIPTION
### Motivation
- Restore the real PWA installation behavior so the browser offers a standalone “Install app” instead of creating shortcuts. 
- Remove any manual-install fallback, alerts or heuristics that caused degraded install behavior on Android browsers. 
- Keep the implementation simple and strictly aligned with the standard `beforeinstallprompt` / `deferredInstallPrompt` flow.

### Description
- Changed `updateInstallButtonVisibility()` to show the `install-btn` only when `deferredInstallPrompt` exists and the app is not already installed (use `Boolean(deferredInstallPrompt) && !isAppInstalled()`).
- Updated the `install-btn` click handler to call `deferredInstallPrompt.prompt()`, await `deferredInstallPrompt.userChoice`, hide the button only if `choice.outcome === 'accepted'`, and then clear `deferredInstallPrompt` without showing any alerts or fallbacks.
- Removed the manual-install modal invocation and the `showManualInstallNotice()` function so no manual fallback UI or messages are presented.
- Preserved the canonical `beforeinstallprompt` handler (with `event.preventDefault()` and storing the event in `deferredInstallPrompt`) and the `appinstalled` handler, and left other files (manifest, service worker, update banner) untouched.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697215fab580832f8892f7b4d8a47a69)