### PR TITLE
Restore canonical PWA install flow, fix manifest icons, and improve SW navigation caching

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "Adivina la Canción",
-  "short_name": "Adivina la Canción",
+  "short_name": "Adivina",
   "start_url": "/",
+  "id": "/",
   "scope": "/",
   "display": "standalone",
   "background_color": "#1b0b2c",
@@ -10,25 +11,15 @@
   "icons": [
     {
       "src": "img/adivina.png",
-      "sizes": "1024x1024",
-      "type": "image/png",
-      "purpose": "any maskable"
-    },
-    {
-      "src": "img/adivina.png",
       "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "img/adivina.png",
-      "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "img/adivina.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Restore the standard PWA install behavior so the browser shows the native “Install app” flow instead of producing a shortcut.
- Remove the manual-install fallback UI that prompted users to “Añadir a pantalla de inicio” and caused shortcut installs.
- Make the manifest and service worker more robust so installs are stable on Android and navigation works offline.

### Description
- Move `beforeinstallprompt` and `appinstalled` listeners to top-level (loaded immediately in `public/js/main.js`) and update the UI reactively when `deferredInstallPrompt` changes. 
- Make `updateInstallButtonVisibility()` show the install button only when `Boolean(deferredInstallPrompt)` and the app is not installed, and simplify `initializeInstallPrompt()` to call `deferredInstallPrompt.prompt()`, `await deferredInstallPrompt.userChoice`, clear `deferredInstallPrompt`, and update visibility. 
- Remove the manual install notice and any code that showed fallback instructions for adding a shortcut, so no manual A2HS UI is presented. 
- Update `public/manifest.json` to set a shorter `short_name` (`"Adivina"`), add `"id": "/"`, and keep only `purpose: "any"` entries for the `192` and `512` icons (remove `maskable`/duplicate maskable entries) to avoid maskable/transparency issues. 
- Update `public/sw.js` navigation handling to a network-first strategy that caches the network response into the runtime cache for both `/index.html` and `/` and falls back to the cached `index.html` or `/` on failure, while preserving the existing asset caching behavior.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697215fab580832f8892f7b4d8a47a69)